### PR TITLE
feat(inspect): add structured observability output for PDF signature inspection

### DIFF
--- a/bin/signer-inspect
+++ b/bin/signer-inspect
@@ -51,6 +51,169 @@ function hasPattern(string $content, string $pattern): bool
     return preg_match($pattern, $content) === 1;
 }
 
+/**
+ * @return array{mode:string,has_xref_table:bool,has_xref_stream:bool,startxref:int|null}
+ */
+function detectXrefMode(string $pdfContent): array
+{
+    $hasXrefTable = preg_match('/(?:^|\R)xref\R/s', $pdfContent) === 1;
+    $hasXrefStream = preg_match('/\/Type\s*\/XRef\b/', $pdfContent) === 1;
+
+    $mode = 'unknown';
+    if ($hasXrefTable && $hasXrefStream) {
+        $mode = 'hybrid';
+    } elseif ($hasXrefStream) {
+        $mode = 'stream';
+    } elseif ($hasXrefTable) {
+        $mode = 'table';
+    }
+
+    $startxref = null;
+    if (preg_match_all('/startxref\s*([0-9]+)\s*%%EOF/ms', $pdfContent, $matches) > 0) {
+        $last = $matches[1][count($matches[1]) - 1] ?? null;
+        if (is_string($last) && $last !== '') {
+            $startxref = (int) $last;
+        }
+    }
+
+    return [
+        'mode' => $mode,
+        'has_xref_table' => $hasXrefTable,
+        'has_xref_stream' => $hasXrefStream,
+        'startxref' => $startxref,
+    ];
+}
+
+/**
+ * @return array<int, array{index:int,startxref:int,eof_offset:int,revision_start:int,revision_end:int}>
+ */
+function detectIncrementalRevisions(string $pdfContent): array
+{
+    $matches = [];
+    preg_match_all('/startxref\s*([0-9]+)\s*%%EOF/ms', $pdfContent, $matches, PREG_OFFSET_CAPTURE);
+
+    $revisions = [];
+    $previousEnd = -1;
+    foreach ($matches[0] ?? [] as $index => $match) {
+        $full = $match[0];
+        $offset = (int) $match[1];
+        $eofEnd = $offset + strlen($full) - 1;
+        $startxref = isset($matches[1][$index][0]) ? (int) $matches[1][$index][0] : 0;
+
+        $revisionStart = $previousEnd + 1;
+        $revisions[] = [
+            'index' => $index,
+            'startxref' => $startxref,
+            'eof_offset' => $offset,
+            'revision_start' => max(0, $revisionStart),
+            'revision_end' => max(0, $eofEnd),
+        ];
+
+        $previousEnd = $eofEnd;
+    }
+
+    return $revisions;
+}
+
+/**
+ * @return array<int, array<string, mixed>>
+ */
+function extractSignatureDictionaryDetails(string $pdfContent): array
+{
+    $matches = [];
+    preg_match_all('/\/ByteRange\s*\[\s*(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s*\]/', $pdfContent, $matches, PREG_OFFSET_CAPTURE);
+
+    $details = [];
+    foreach ($matches[0] ?? [] as $index => $fullMatch) {
+        $offset = (int) $fullMatch[1];
+        $start = strrpos(substr($pdfContent, 0, $offset), '<<');
+        $end = strpos($pdfContent, '>>', $offset);
+        if ($start === false || $end === false || $end <= $start) {
+            continue;
+        }
+
+        $dictionary = substr($pdfContent, $start, $end - $start + 2);
+        if (! is_string($dictionary) || ! preg_match('/\/Type\s*\/Sig\b/', $dictionary)) {
+            continue;
+        }
+
+        $contentsHexLength = null;
+        if (preg_match('/\/Contents\s*<([0-9A-Fa-f\s]+)>/s', $dictionary, $contentMatch) === 1) {
+            $hex = preg_replace('/\s+/', '', $contentMatch[1] ?? '');
+            if (is_string($hex)) {
+                $contentsHexLength = strlen($hex);
+            }
+        }
+
+        $details[] = [
+            'signature_index' => count($details),
+            'has_filter' => preg_match('/\/Filter\b/', $dictionary) === 1,
+            'has_subfilter' => preg_match('/\/SubFilter\b/', $dictionary) === 1,
+            'has_reason' => preg_match('/\/Reason\b/', $dictionary) === 1,
+            'has_name' => preg_match('/\/Name\b/', $dictionary) === 1,
+            'has_m' => preg_match('/\/M\b/', $dictionary) === 1,
+            'has_location' => preg_match('/\/Location\b/', $dictionary) === 1,
+            'has_contact_info' => preg_match('/\/ContactInfo\b/', $dictionary) === 1,
+            'has_reference' => preg_match('/\/Reference\b/', $dictionary) === 1,
+            'has_contents' => preg_match('/\/Contents\b/', $dictionary) === 1,
+            'contents_hex_length' => $contentsHexLength,
+            'dictionary_span' => [
+                'start_offset' => $start,
+                'end_offset' => $end + 1,
+            ],
+        ];
+    }
+
+    return $details;
+}
+
+/**
+ * @return array{has_appearance:bool,widget_count:int,ap_n_count:int,xobject_count:int,trace:array<int, string>}
+ */
+function analyzeAppearance(string $pdfContent): array
+{
+    $widgetCount = (int) preg_match_all('/\/Subtype\s*\/Widget\b/', $pdfContent, $unused);
+    $apNCount = (int) preg_match_all('/\/AP\s*<<[^>]*\/N\b/s', $pdfContent, $unused2);
+    $xObjectCount = (int) preg_match_all('/\/Type\s*\/XObject\b/', $pdfContent, $unused3);
+
+    $trace = [];
+    if ($widgetCount > 0) {
+        $trace[] = 'widget-annotations-detected';
+    }
+    if ($apNCount > 0) {
+        $trace[] = 'appearance-normal-stream-detected';
+    }
+    if ($xObjectCount > 0) {
+        $trace[] = 'xobject-resources-detected';
+    }
+
+    return [
+        'has_appearance' => $widgetCount > 0 || $apNCount > 0,
+        'widget_count' => $widgetCount,
+        'ap_n_count' => $apNCount,
+        'xobject_count' => $xObjectCount,
+        'trace' => $trace,
+    ];
+}
+
+/**
+ * @return array{has_dss:bool,has_vri:bool,has_ocsps:bool,has_crls:bool,has_certs:bool,vri_entry_hint_count:int,ocsp_stream_hint_count:int,crl_stream_hint_count:int,cert_stream_hint_count:int}
+ */
+function analyzeLtvAssembly(string $pdfContent): array
+{
+    return [
+        'has_dss' => preg_match('/\/DSS\b/', $pdfContent) === 1,
+        'has_vri' => preg_match('/\/VRI\b/', $pdfContent) === 1,
+        'has_ocsps' => preg_match('/\/OCSPs\b/', $pdfContent) === 1,
+        'has_crls' => preg_match('/\/CRLs\b/', $pdfContent) === 1,
+        'has_certs' => preg_match('/\/Certs\b/', $pdfContent) === 1,
+        'vri_entry_hint_count' => (int) preg_match_all('/\/VRI\b/', $pdfContent, $unused),
+        'ocsp_stream_hint_count' => (int) preg_match_all('/\/OCSPs\b/', $pdfContent, $unused2),
+        'crl_stream_hint_count' => (int) preg_match_all('/\/CRLs\b/', $pdfContent, $unused3),
+        'cert_stream_hint_count' => (int) preg_match_all('/\/Certs\b/', $pdfContent, $unused4),
+    ];
+}
+
 function inferProfile(bool $hasSignatures, bool $hasCades, int $docTimestampCount, bool $hasDss): string
 {
     if (! $hasSignatures) {
@@ -246,6 +409,22 @@ $revocationSummary['risk_flags'] = [
     'crl_unreachable' => $revocationSummary['crl_unreachable_urls'] !== [],
 ];
 
+$xref = detectXrefMode($pdfContent);
+$revisions = detectIncrementalRevisions($pdfContent);
+$signatureDictionaryDetails = extractSignatureDictionaryDetails($pdfContent);
+$appearance = analyzeAppearance($pdfContent);
+$ltvAssembly = analyzeLtvAssembly($pdfContent);
+
+$byteRangeFinalVerification = [];
+foreach ($signatureExtractor->extract($pdfContent) as $signature) {
+    $byteRangeFinalVerification[] = [
+        'signature_index' => $signature->index,
+        'byte_range' => $signature->byteRange,
+        'byte_range_valid' => $signature->byteRangeValid,
+        'byte_range_error' => $signature->byteRangeError,
+    ];
+}
+
 $report = [
     'file' => $inputPath,
     'size_bytes' => strlen($pdfContent),
@@ -266,6 +445,26 @@ $report = [
         'has_vri' => $hasVri,
         'has_ocsps' => $hasOcsps,
         'has_crls' => $hasCrls,
+    ],
+    'observability' => [
+        'xref' => $xref,
+        'incremental_revisions' => [
+            'count' => count($revisions),
+            'boundaries' => $revisions,
+        ],
+        'byte_range' => [
+            'planning' => [
+                'available' => false,
+                'reason' => 'Planning data requires signing context instrumentation.',
+            ],
+            'final_verification' => $byteRangeFinalVerification,
+        ],
+        'signature_dictionary_assembly' => [
+            'signatures_count' => count($signatureDictionaryDetails),
+            'details' => $signatureDictionaryDetails,
+        ],
+        'appearance_stream_generation' => $appearance,
+        'dss_vri_assembly' => $ltvAssembly,
     ],
     'revocation_endpoints' => $signatureDetails,
     'revocation_risk_summary' => $revocationSummary,

--- a/tests/E2E/PdfGoldenContractTest.php
+++ b/tests/E2E/PdfGoldenContractTest.php
@@ -27,6 +27,35 @@ final class PdfGoldenContractTest extends TestCase
         $report = json_decode($reportJson, true);
         self::assertIsArray($report);
 
+        self::assertArrayHasKey('observability', $report);
+        self::assertIsArray($report['observability']);
+
+        self::assertArrayHasKey('xref', $report['observability']);
+        self::assertArrayHasKey('mode', $report['observability']['xref']);
+        self::assertContains($report['observability']['xref']['mode'], ['table', 'stream', 'hybrid', 'unknown']);
+
+        self::assertArrayHasKey('incremental_revisions', $report['observability']);
+        self::assertIsArray($report['observability']['incremental_revisions']);
+        self::assertArrayHasKey('count', $report['observability']['incremental_revisions']);
+        self::assertArrayHasKey('boundaries', $report['observability']['incremental_revisions']);
+        self::assertIsArray($report['observability']['incremental_revisions']['boundaries']);
+
+        self::assertArrayHasKey('byte_range', $report['observability']);
+        self::assertArrayHasKey('planning', $report['observability']['byte_range']);
+        self::assertArrayHasKey('final_verification', $report['observability']['byte_range']);
+        self::assertIsArray($report['observability']['byte_range']['final_verification']);
+
+        self::assertArrayHasKey('signature_dictionary_assembly', $report['observability']);
+        self::assertArrayHasKey('details', $report['observability']['signature_dictionary_assembly']);
+        self::assertIsArray($report['observability']['signature_dictionary_assembly']['details']);
+
+        self::assertArrayHasKey('appearance_stream_generation', $report['observability']);
+        self::assertArrayHasKey('has_appearance', $report['observability']['appearance_stream_generation']);
+
+        self::assertArrayHasKey('dss_vri_assembly', $report['observability']);
+        self::assertArrayHasKey('has_dss', $report['observability']['dss_vri_assembly']);
+        self::assertArrayHasKey('has_vri', $report['observability']['dss_vri_assembly']);
+
         $actual = [
             'has_signatures' => (bool) ($report['signatures']['has_signatures'] ?? false),
             'count' => (int) ($report['signatures']['count'] ?? 0),


### PR DESCRIPTION
This PR improves `signer-inspect` output so signature analysis is easier to understand and debug in real-world flows.

It adds a dedicated `observability` section to the JSON output with:
- xref mode detection and final `startxref`
- incremental revision boundaries
- ByteRange final verification details per signature
- signature dictionary assembly details
- appearance stream generation traces
- DSS/VRI assembly details

The goal is to make inspection output more explicit and actionable in binary-level PDF signing scenarios.