### PR TITLE
fix(pdfcore): support raw-deflate and gzip FlateDecode streams

### DIFF
--- a/src/Infrastructure/PdfCore/PDFObject.php
+++ b/src/Infrastructure/PdfCore/PDFObject.php
@@ -190,19 +190,36 @@ endstream
 
     private static function inflateFlateStream(string $stream): string
     {
-        // FlateDecode payloads in the wild may come as zlib, raw deflate, or
-        // (rarely) gzip wrappers. Try each supported inflate mode explicitly.
-        $inflated = @gzuncompress($stream);
-        if (is_string($inflated)) {
-            return $inflated;
+        // ISO 32000 §7.4.4 mandates zlib (RFC 1950) for FlateDecode, but
+        // non-conforming generators produce raw deflate (RFC 1951) or gzip
+        // (RFC 1952). Each format has a deterministic byte-level signature,
+        // so we dispatch without guessing.
+        $b0 = strlen($stream) > 1 ? ord($stream[0]) : -1;
+        $b1 = strlen($stream) > 1 ? ord($stream[1]) : -1;
+
+        // Gzip: magic bytes 0x1F 0x8B (RFC 1952).
+        if ($b0 === 0x1F && $b1 === 0x8B) {
+            $inflated = @gzdecode($stream);
+            if (is_string($inflated)) {
+                return $inflated;
+            }
+
+            throw new PdfCoreParsingException('Failed to inflate FlateDecode stream.');
         }
 
+        // zlib: CMF+FLG header where (CMF*256+FLG) % 31 === 0 and CM (lower 4
+        // bits of CMF) === 8 (deflate). (RFC 1950)
+        if ($b0 !== -1 && ($b0 & 0x0F) === 8 && ($b0 * 256 + $b1) % 31 === 0) {
+            $inflated = @gzuncompress($stream);
+            if (is_string($inflated)) {
+                return $inflated;
+            }
+
+            throw new PdfCoreParsingException('Failed to inflate FlateDecode stream.');
+        }
+
+        // Raw deflate (RFC 1951): no wrapper header.
         $inflated = @gzinflate($stream);
-        if (is_string($inflated)) {
-            return $inflated;
-        }
-
-        $inflated = @gzdecode($stream);
         if (is_string($inflated)) {
             return $inflated;
         }

--- a/src/Infrastructure/PdfCore/PDFObject.php
+++ b/src/Infrastructure/PdfCore/PDFObject.php
@@ -188,12 +188,45 @@ endstream
         return $decoded->raw();
     }
 
+    /**
+     * Decompress a FlateDecode stream using format-aware detection.
+     *
+     * **Compression Format Specification**
+     *
+     * ISO 32000-1:2008 §7.4.4 and ISO 32000-2:2020 §7.4.4 mandate that FlateDecode streams
+     * must use the zlib format as defined in RFC 1950, which combines the DEFLATE algorithm
+     * (RFC 1951) with a 2-byte CMF+FLG header and an Adler-32 checksum. This is the only
+     * conforming format.
+     *
+     * In practice, non-conforming PDF generators (particularly tools targeting Windows or
+     * legacy systems) produce streams in two other formats:
+     *
+     *   - **Raw DEFLATE (RFC 1951)**: No header or checksum. Difficult to distinguish from
+     *     corrupted data without attempting decompression.
+     *   - **GZIP (RFC 1952)**: Includes its own 2-byte magic header (0x1F 0x8B) for tar/gzip
+     *     compatibility. Rare in PDFs but seen in output from cross-platform tools.
+     *
+     * **Format Detection**
+     *
+     * Each format is identifiable by its initial bytes, allowing deterministic dispatch instead
+     * of blind trial-and-error:
+     *
+     *   | Format | Signature | PHP Function | RFC |
+     *   |---|---|---|---|
+     *   | GZIP | magic bytes 0x1F 0x8B | gzdecode() | RFC 1952 |
+     *   | zlib | CMF byte & 0x0F == 8, (CMF*256+FLG) % 31 == 0 | gzuncompress() | RFC 1950 |
+     *   | raw DEFLATE | none (absence of above) | gzinflate() | RFC 1951 |
+     *
+     * This approach is more robust than sequential attempt-and-error because:
+     *   1. Non-blocking: avoids suppressing real errors with `@` operator
+     *   2. Semantically correct: error is thrown only when format is correctly identified
+     *     but fails to decompress, not after exhausting all variants
+     *   3. Consistent with major PDF engines (libpoppler, PDFium, Apache PDFBox)
+     *
+     * @throws PdfCoreParsingException if the stream cannot be decompressed after format detection
+     */
     private static function inflateFlateStream(string $stream): string
     {
-        // ISO 32000 §7.4.4 mandates zlib (RFC 1950) for FlateDecode, but
-        // non-conforming generators produce raw deflate (RFC 1951) or gzip
-        // (RFC 1952). Each format has a deterministic byte-level signature,
-        // so we dispatch without guessing.
         $b0 = strlen($stream) > 1 ? ord($stream[0]) : -1;
         $b1 = strlen($stream) > 1 ? ord($stream[1]) : -1;
 

--- a/src/Infrastructure/PdfCore/PDFObject.php
+++ b/src/Infrastructure/PdfCore/PDFObject.php
@@ -189,41 +189,14 @@ endstream
     }
 
     /**
-     * Decompress a FlateDecode stream using format-aware detection.
+     * Decompress FlateDecode stream by format-aware detection (RFC 1950, 1951, 1952).
      *
-     * **Compression Format Specification**
+     * ISO 32000 mandates zlib (RFC 1950), but non-conforming generators produce raw deflate
+     * (RFC 1951) or gzip (RFC 1952). Each format has a deterministic byte signature:
+     * gzip (0x1F 0x8B) → gzdecode(), zlib (CMF header checksum) → gzuncompress(),
+     * everything else → gzinflate(). This avoids blind trial-and-error.
      *
-     * ISO 32000-1:2008 §7.4.4 and ISO 32000-2:2020 §7.4.4 mandate that FlateDecode streams
-     * must use the zlib format as defined in RFC 1950, which combines the DEFLATE algorithm
-     * (RFC 1951) with a 2-byte CMF+FLG header and an Adler-32 checksum. This is the only
-     * conforming format.
-     *
-     * In practice, non-conforming PDF generators (particularly tools targeting Windows or
-     * legacy systems) produce streams in two other formats:
-     *
-     *   - **Raw DEFLATE (RFC 1951)**: No header or checksum. Difficult to distinguish from
-     *     corrupted data without attempting decompression.
-     *   - **GZIP (RFC 1952)**: Includes its own 2-byte magic header (0x1F 0x8B) for tar/gzip
-     *     compatibility. Rare in PDFs but seen in output from cross-platform tools.
-     *
-     * **Format Detection**
-     *
-     * Each format is identifiable by its initial bytes, allowing deterministic dispatch instead
-     * of blind trial-and-error:
-     *
-     *   | Format | Signature | PHP Function | RFC |
-     *   |---|---|---|---|
-     *   | GZIP | magic bytes 0x1F 0x8B | gzdecode() | RFC 1952 |
-     *   | zlib | CMF byte & 0x0F == 8, (CMF*256+FLG) % 31 == 0 | gzuncompress() | RFC 1950 |
-     *   | raw DEFLATE | none (absence of above) | gzinflate() | RFC 1951 |
-     *
-     * This approach is more robust than sequential attempt-and-error because:
-     *   1. Non-blocking: avoids suppressing real errors with `@` operator
-     *   2. Semantically correct: error is thrown only when format is correctly identified
-     *     but fails to decompress, not after exhausting all variants
-     *   3. Consistent with major PDF engines (libpoppler, PDFium, Apache PDFBox)
-     *
-     * @throws PdfCoreParsingException if the stream cannot be decompressed after format detection
+     * @throws PdfCoreParsingException
      */
     private static function inflateFlateStream(string $stream): string
     {

--- a/src/Infrastructure/PdfCore/PDFObject.php
+++ b/src/Infrastructure/PdfCore/PDFObject.php
@@ -188,6 +188,28 @@ endstream
         return $decoded->raw();
     }
 
+    private static function inflateFlateStream(string $stream): string
+    {
+        // FlateDecode payloads in the wild may come as zlib, raw deflate, or
+        // (rarely) gzip wrappers. Try each supported inflate mode explicitly.
+        $inflated = @gzuncompress($stream);
+        if (is_string($inflated)) {
+            return $inflated;
+        }
+
+        $inflated = @gzinflate($stream);
+        if (is_string($inflated)) {
+            return $inflated;
+        }
+
+        $inflated = @gzdecode($stream);
+        if (is_string($inflated)) {
+            return $inflated;
+        }
+
+        throw new PdfCoreParsingException('Failed to inflate FlateDecode stream.');
+    }
+
     public function getStream($raw = true): string
     {
         if ($raw === true) {
@@ -205,10 +227,7 @@ endstream
                         'Colors' => $DecodeParams['Colors'] ?? new PDFValueSimple(1),
                     ];
 
-                    $inflated = gzuncompress((string) $this->stream);
-                    if ($inflated === false) {
-                        throw new PdfCoreParsingException('Failed to inflate FlateDecode stream.');
-                    }
+                    $inflated = self::inflateFlateStream((string) $this->stream);
 
                     return self::flateDecode($inflated, $params);
                 default:

--- a/tests/Unit/PDFObjectTest.php
+++ b/tests/Unit/PDFObjectTest.php
@@ -220,9 +220,29 @@ final class PDFObjectTest extends TestCase
         self::assertIsString($payload);
         $object->setStream($payload);
 
-        $decoded = $object->getStream(false);
+        self::assertSame('abc', $object->getStream(false));
+    }
 
-        self::assertSame('abc', $decoded);
+    public function test_get_stream_decodes_gzip_flate_payload(): void
+    {
+        $object = new PDFObject(1, ['Filter' => '/FlateDecode']);
+
+        $payload = gzencode('abc');
+        self::assertIsString($payload);
+        $object->setStream($payload);
+
+        self::assertSame('abc', $object->getStream(false));
+    }
+
+    public function test_get_stream_decodes_zlib_flate_payload(): void
+    {
+        $object = new PDFObject(1, ['Filter' => '/FlateDecode']);
+
+        $payload = gzcompress('abc');
+        self::assertIsString($payload);
+        $object->setStream($payload);
+
+        self::assertSame('abc', $object->getStream(false));
     }
 
     public function test_get_stream_throws_for_invalid_columns_when_predictor_requires_it(): void

--- a/tests/Unit/PDFObjectTest.php
+++ b/tests/Unit/PDFObjectTest.php
@@ -212,33 +212,24 @@ final class PDFObjectTest extends TestCase
         }
     }
 
-    public function test_get_stream_decodes_raw_deflate_flate_payload(): void
+    /**
+     * @return array<string, array{callable(string):string|false}>
+     */
+    public static function flateEncodeVariants(): array
     {
-        $object = new PDFObject(1, ['Filter' => '/FlateDecode']);
-
-        $payload = gzdeflate('abc');
-        self::assertIsString($payload);
-        $object->setStream($payload);
-
-        self::assertSame('abc', $object->getStream(false));
+        return [
+            'zlib (RFC 1950 — mandated by ISO 32000)' => ['gzcompress'],
+            'raw deflate (RFC 1951 — non-conforming generators)' => ['gzdeflate'],
+            'gzip (RFC 1952 — rare non-conforming generators)' => ['gzencode'],
+        ];
     }
 
-    public function test_get_stream_decodes_gzip_flate_payload(): void
+    #[\PHPUnit\Framework\Attributes\DataProvider('flateEncodeVariants')]
+    public function test_get_stream_decodes_flatedecode_for_all_wire_formats(callable $encoder): void
     {
         $object = new PDFObject(1, ['Filter' => '/FlateDecode']);
 
-        $payload = gzencode('abc');
-        self::assertIsString($payload);
-        $object->setStream($payload);
-
-        self::assertSame('abc', $object->getStream(false));
-    }
-
-    public function test_get_stream_decodes_zlib_flate_payload(): void
-    {
-        $object = new PDFObject(1, ['Filter' => '/FlateDecode']);
-
-        $payload = gzcompress('abc');
+        $payload = $encoder('abc');
         self::assertIsString($payload);
         $object->setStream($payload);
 

--- a/tests/Unit/PDFObjectTest.php
+++ b/tests/Unit/PDFObjectTest.php
@@ -212,6 +212,19 @@ final class PDFObjectTest extends TestCase
         }
     }
 
+    public function test_get_stream_decodes_raw_deflate_flate_payload(): void
+    {
+        $object = new PDFObject(1, ['Filter' => '/FlateDecode']);
+
+        $payload = gzdeflate('abc');
+        self::assertIsString($payload);
+        $object->setStream($payload);
+
+        $decoded = $object->getStream(false);
+
+        self::assertSame('abc', $decoded);
+    }
+
     public function test_get_stream_throws_for_invalid_columns_when_predictor_requires_it(): void
     {
         $object = new PDFObject(1, [


### PR DESCRIPTION
## Problem

ISO 32000 §7.4.4 mandates that FlateDecode streams use the zlib format (RFC 1950), but a significant number of PDFs produced by non-conforming generators use raw deflate (RFC 1951) or, rarely, gzip (RFC 1952) wrappers. The previous implementation called only `gzuncompress()` (zlib) and treated any failure as a fatal error, causing fail with `Failed to inflate FlateDecode stream`.

## Solution

Instead of trying each inflate variant blindly, the stream header bytes are inspected deterministically:

| Format | Detection | PHP function |
|---|---|---|
| gzip (RFC 1952) | magic bytes `0x1F 0x8B` | `gzdecode()` |
| zlib (RFC 1950) | `(CMF & 0x0F) === 8` and `(CMF*256+FLG) % 31 === 0` | `gzuncompress()` |
| raw deflate (RFC 1951) | everything else | `gzinflate()` |

This avoids unnecessary attempts and makes non-conformant cases explicit, an error is thrown only when the detected format fails to decompress, not after exhausting all variants.
