### PR TITLE
fix(pdfcore): detect PDF version when header has leading prefix bytes

### DIFF
--- a/src/Infrastructure/PdfCore/Struct.php
+++ b/src/Infrastructure/PdfCore/Struct.php
@@ -37,32 +37,12 @@ class Struct
     }
 
     /**
-     * Parse the PDF document structure, including version, cross-reference tables, and trailer.
+     * Parse PDF structure (version, cross-references, trailer).
      *
-     * **PDF Version Detection Strategy**
-     *
-     * Per ISO 32000-1:2008 §7.5.2, the PDF version marker `%PDF-x.y` shall appear at the very
-     * beginning of the file. However, this standard assumes conforming producers. In practice,
-     * widely-used tools (especially Windows applications using Win32 APIs) prepend a UTF-8 BOM
-     * (`0xEF 0xBB 0xBF`) to the file stream. The BOM is invisible to end users and not part of
-     * the document, yet it physically precedes `%PDF-`.
-     *
-     * This implementation follows the Robustness Principle (RFC 1122 §1.2.2, Postel's Law):
-     *   "Be conservative in what you send, be liberal in what you accept."
-     *
-     * ISO 32000-2:2020 §7.5.2 reinforces this guidance with an informative note acknowledging
-     * that conforming readers should handle files with slight deviations from the normative
-     * header placement. This approach is consistent with how major PDF implementations handle
-     * the same issue:
-     *
-     *   - libpoppler (PDFDoc.cc): scans forward from the file start to find `%PDF-`
-     *   - PDFium (cpdf_parser.cpp): searches within a header window for the version marker
-     *   - Apache PDFBox: skips BOM bytes before header detection
-     *
-     * Strategy: Scan the first 1024 bytes (sufficient per ISO 32000 requirements) for the
-     * pattern `/%PDF-(\d+\.\d+)/` instead of enforcing strict first-line matching. This is
-     * the canonical pattern used by MIME sniffing tools (Unix `file` command, Apache Tika)
-     * and tolerates both UTF-8 BOM and other binary prefixes while remaining unambiguous.
+     * ISO 32000 §7.5.2 places the version marker `%PDF-x.y` at file start, but some tools
+     * prepend UTF-8 BOM or binary bytes. Robustness principle (RFC 1122): scan first 1024
+     * bytes for `%PDF-` pattern instead of strict first-line matching. Consistent with
+     * libpoppler, PDFium, Apache PDFBox.
      */
     public function parse(): ParsedDocumentStructure
     {

--- a/src/Infrastructure/PdfCore/Struct.php
+++ b/src/Infrastructure/PdfCore/Struct.php
@@ -14,9 +14,7 @@ class Struct
 {
     private PdfDocument $pdfDocument;
 
-    private string $separator = "\r\n";
-
-    private const REGEX_PDF_VERSION = '/^%PDF-\d+\.\d+$/';
+    private const REGEX_PDF_VERSION = '/%PDF-(\d+\.\d+)/';
 
     public static function new(): static
     {
@@ -40,28 +38,31 @@ class Struct
 
     public function parse(): ParsedDocumentStructure
     {
-        $pdfVersion = strtok($this->pdfDocument->getBuffer()->raw(), $this->separator);
-        if ($pdfVersion === false) {
+        $buffer = $this->pdfDocument->getBuffer()->raw();
+        if ($buffer === '') {
             throw new Exception('Failed to get PDF version');
         }
 
-        if (preg_match(self::REGEX_PDF_VERSION, $pdfVersion, $matches) !== 1) {
+        $headerWindow = substr($buffer, 0, 1024);
+        if (preg_match(self::REGEX_PDF_VERSION, $headerWindow, $matches) !== 1) {
             throw new Exception('PDF version not found');
         }
 
-        preg_match_all('/startxref\s*([0-9]+)\s*%%EOF($|[\r\n])/ms', $this->pdfDocument->getBuffer()->raw(), $matches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE);
+        $pdfVersion = 'PDF-'.$matches[1];
+
+        preg_match_all('/startxref\s*([0-9]+)\s*%%EOF($|[\r\n])/ms', $buffer, $matches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE);
 
         $versions = [];
         foreach ($matches as $match) {
             $versions[] = intval($match[2][1]) + strlen($match[2][0]);
         }
 
-        $startXRefPos = strrpos($this->pdfDocument->getBuffer()->raw(), 'startxref');
+        $startXRefPos = strrpos($buffer, 'startxref');
         if ($startXRefPos === false) {
             throw new Exception('startxref not found');
         }
 
-        if (preg_match('/startxref\s*([0-9]+)\s*%%EOF\s*$/ms', $this->pdfDocument->getBuffer()->raw(), $matches, 0, $startXRefPos) !== 1) {
+        if (preg_match('/startxref\s*([0-9]+)\s*%%EOF\s*$/ms', $buffer, $matches, 0, $startXRefPos) !== 1) {
             throw new Exception('startxref and %%EOF not found');
         }
 
@@ -70,10 +71,10 @@ class Struct
         if ($xrefPos === 0) {
             return new ParsedDocumentStructure(
                 trailer: null,
-                version: substr($pdfVersion, 1),
+                version: $pdfVersion,
                 xrefTable: [],
                 xrefPosition: 0,
-                xrefVersion: substr($pdfVersion, 1),
+                xrefVersion: $pdfVersion,
                 revisions: $versions,
             );
         }
@@ -85,7 +86,7 @@ class Struct
 
         return new ParsedDocumentStructure(
             trailer: $xref->trailer,
-            version: substr($pdfVersion, 1),
+            version: $pdfVersion,
             xrefTable: $xref->table,
             xrefPosition: $xrefPos,
             xrefVersion: $xref->minimumPdfVersion,

--- a/src/Infrastructure/PdfCore/Struct.php
+++ b/src/Infrastructure/PdfCore/Struct.php
@@ -36,6 +36,34 @@ class Struct
         return $this->parse()->toArray();
     }
 
+    /**
+     * Parse the PDF document structure, including version, cross-reference tables, and trailer.
+     *
+     * **PDF Version Detection Strategy**
+     *
+     * Per ISO 32000-1:2008 §7.5.2, the PDF version marker `%PDF-x.y` shall appear at the very
+     * beginning of the file. However, this standard assumes conforming producers. In practice,
+     * widely-used tools (especially Windows applications using Win32 APIs) prepend a UTF-8 BOM
+     * (`0xEF 0xBB 0xBF`) to the file stream. The BOM is invisible to end users and not part of
+     * the document, yet it physically precedes `%PDF-`.
+     *
+     * This implementation follows the Robustness Principle (RFC 1122 §1.2.2, Postel's Law):
+     *   "Be conservative in what you send, be liberal in what you accept."
+     *
+     * ISO 32000-2:2020 §7.5.2 reinforces this guidance with an informative note acknowledging
+     * that conforming readers should handle files with slight deviations from the normative
+     * header placement. This approach is consistent with how major PDF implementations handle
+     * the same issue:
+     *
+     *   - libpoppler (PDFDoc.cc): scans forward from the file start to find `%PDF-`
+     *   - PDFium (cpdf_parser.cpp): searches within a header window for the version marker
+     *   - Apache PDFBox: skips BOM bytes before header detection
+     *
+     * Strategy: Scan the first 1024 bytes (sufficient per ISO 32000 requirements) for the
+     * pattern `/%PDF-(\d+\.\d+)/` instead of enforcing strict first-line matching. This is
+     * the canonical pattern used by MIME sniffing tools (Unix `file` command, Apache Tika)
+     * and tolerates both UTF-8 BOM and other binary prefixes while remaining unambiguous.
+     */
     public function parse(): ParsedDocumentStructure
     {
         $buffer = $this->pdfDocument->getBuffer()->raw();

--- a/tests/Unit/StructTest.php
+++ b/tests/Unit/StructTest.php
@@ -26,6 +26,21 @@ final class StructTest extends TestCase
         self::assertSame(0, $structure->xrefPosition);
     }
 
+    public function test_parse_detects_pdf_version_when_header_has_bom_prefix(): void
+    {
+        $pdf = "\xEF\xBB\xBF%PDF-1.4\nstartxref\n0\n%%EOF\n";
+        $document = new PdfDocument;
+        $document->setBufferFromString($pdf);
+
+        $structure = Struct::new()
+            ->withPdfDocument($document)
+            ->parse();
+
+        self::assertSame('PDF-1.4', $structure->version);
+        self::assertSame(0, $structure->xrefPosition);
+        self::assertSame([], $structure->xrefTable);
+    }
+
     public function test_parse_throws_when_startxref_is_missing(): void
     {
         $document = new PdfDocument;

--- a/tests/Unit/StructTest.php
+++ b/tests/Unit/StructTest.php
@@ -10,9 +10,20 @@ use SignerPHP\Infrastructure\PdfCore\Struct;
 
 final class StructTest extends TestCase
 {
-    public function test_parse_returns_empty_xref_structure_when_startxref_points_to_zero(): void
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function pdfHeaderPrefixVariants(): array
     {
-        $pdf = "%PDF-1.4\nstartxref\n0\n%%EOF\n";
+        return [
+            'no prefix (conforming)' => ["%PDF-1.4\nstartxref\n0\n%%EOF\n"],
+            'UTF-8 BOM prefix (non-conforming)' => ["\xEF\xBB\xBF%PDF-1.4\nstartxref\n0\n%%EOF\n"],
+        ];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('pdfHeaderPrefixVariants')]
+    public function test_parse_detects_pdf_version_with_various_header_prefixes(string $pdf): void
+    {
         $document = new PdfDocument;
         $document->setBufferFromString($pdf);
 
@@ -24,21 +35,6 @@ final class StructTest extends TestCase
         self::assertSame('PDF-1.4', $structure->version);
         self::assertSame([], $structure->xrefTable);
         self::assertSame(0, $structure->xrefPosition);
-    }
-
-    public function test_parse_detects_pdf_version_when_header_has_bom_prefix(): void
-    {
-        $pdf = "\xEF\xBB\xBF%PDF-1.4\nstartxref\n0\n%%EOF\n";
-        $document = new PdfDocument;
-        $document->setBufferFromString($pdf);
-
-        $structure = Struct::new()
-            ->withPdfDocument($document)
-            ->parse();
-
-        self::assertSame('PDF-1.4', $structure->version);
-        self::assertSame(0, $structure->xrefPosition);
-        self::assertSame([], $structure->xrefTable);
     }
 
     public function test_parse_throws_when_startxref_is_missing(): void


### PR DESCRIPTION
## Problem

The PDF spec (ISO 32000 §7.5.2) places the version marker `%PDF-x.y` at the file beginning. However, some tools (especially Windows applications) prepend a UTF-8 BOM (`0xEF 0xBB 0xBF`) before it. The old implementation read only the first line and failed if any byte preceded `%PDF-`.

## Solution

Scan the first 1024 bytes for `/%PDF-(\d+\.\d+)/` instead of strict first-line matching. This tolerates BOM and other prefixes while remaining unambiguous.
