### PR TITLE
Harden PDF core parsing for malformed and hybrid documents

### DIFF
--- a/src/Infrastructure/PdfCore/ObjectParser.php
+++ b/src/Infrastructure/PdfCore/ObjectParser.php
@@ -130,8 +130,15 @@ class ObjectParser implements Stringable
                     $this->advanceToken();
                     $value = $this->parseValue();
                     if ($value === null) {
+                        if ($this->currentTokenType === self::T_LIST_END) {
+                            // Keep tolerant behavior for stray ']' after a field key.
+                            $this->advanceToken();
+                            break;
+                        }
+
                         throw new PdfCoreParsingException('Invalid null object value for field '.$field);
                     }
+
                     $object[$field] = $value;
                     break;
 
@@ -139,6 +146,15 @@ class ObjectParser implements Stringable
                     $this->advanceToken();
 
                     return new PDFValueObject($object);
+
+                case self::T_COMMENT:
+                    $this->advanceToken();
+                    break;
+
+                case self::T_LIST_END:
+                    // Stray ']' inside a dict — skip (non-conforming but recoverable).
+                    $this->advanceToken();
+                    break;
 
                 default:
                     throw new PdfCoreParsingException('Invalid token: '.$this);
@@ -202,6 +218,7 @@ class ObjectParser implements Stringable
                 case self::T_OBJECT_BEGIN:
                 case self::T_STREAM_END:
                     throw new PdfCoreParsingException('Invalid keyword');
+                case self::T_LIST_END:
                 case self::T_OBJECT_END:
                 case self::T_STREAM_BEGIN:
                     return null;

--- a/src/Infrastructure/PdfCore/PDFObject.php
+++ b/src/Infrastructure/PdfCore/PDFObject.php
@@ -240,7 +240,20 @@ endstream
         }
 
         if (isset($this->value['Filter'])) {
-            switch ($this->value['Filter']) {
+            // Normalise: some generators write Filter as a one-element array [/FlateDecode]
+            // instead of the plain name /FlateDecode (ISO 32000 §7.3.8.2).
+            $filterField = $this->value['Filter'];
+            $filterValues = $filterField->val(true);
+            $filterName = is_array($filterValues) && count($filterValues) === 1
+                ? (string) array_values($filterValues)[0]
+                : (string) $filterField;
+
+            // Re-add leading '/' if the filter value was stored without one.
+            if ($filterName !== '' && $filterName[0] !== '/') {
+                $filterName = '/'.$filterName;
+            }
+
+            switch ($filterName) {
                 case '/FlateDecode':
                     $DecodeParams = $this->value['DecodeParms'] ?? [];
                     $params = [
@@ -254,7 +267,7 @@ endstream
 
                     return self::flateDecode($inflated, $params);
                 default:
-                    throw new PdfCoreStructureException('Unknown compression method '.$this->value['Filter']);
+                    throw new PdfCoreStructureException('Unknown compression method '.$filterName);
             }
         }
 

--- a/src/Infrastructure/PdfCore/PageInfo.php
+++ b/src/Infrastructure/PdfCore/PageInfo.php
@@ -42,7 +42,7 @@ class PageInfo
             throw new PdfCoreStructureException('Could not resolve pages root from document catalog.');
         }
 
-        $this->pagesInfo = $this->getPageInfo($pages);
+        $this->pagesInfo = $this->getPageInfo($pages, null, []);
 
         return $this;
     }
@@ -51,7 +51,7 @@ class PageInfo
      * @param  array<int, mixed>|null  $inheritedSize
      * @return array<int, PageDescriptor>
      */
-    protected function getPageInfo(int $oid, ?array $inheritedSize = null): array
+    protected function getPageInfo(int $oid, ?array $inheritedSize = null, array $visitedOids = []): array
     {
         $object = $this->pdfDocument->getObject($oid);
         if ($object === null) {
@@ -79,8 +79,12 @@ class PageInfo
                     }
                 }
 
+                $visitedOids[$oid] = true;
                 foreach ($kids as $kid) {
-                    $descriptors = $this->getPageInfo((int) $kid, $currentSize);
+                    if (isset($visitedOids[(int) $kid])) {
+                        continue;
+                    }
+                    $descriptors = $this->getPageInfo((int) $kid, $currentSize, $visitedOids);
                     array_push($pageDescriptors, ...$descriptors);
                 }
 

--- a/src/Infrastructure/PdfCore/Service/ObjectStreamResolver.php
+++ b/src/Infrastructure/PdfCore/Service/ObjectStreamResolver.php
@@ -42,7 +42,9 @@ final class ObjectStreamResolver
 
         $stream = $objstm->getStream(false);
         $index = substr((string) $stream, 0, $firstValue);
-        $index = explode(' ', trim($index));
+        // Split on any whitespace (tabs, multiple spaces, newlines) to tolerate
+        // non-conforming generators that don't use single spaces (ISO 32000 §7.5.7).
+        $index = preg_split('/\s+/', trim($index), -1, PREG_SPLIT_NO_EMPTY);
         $stream = substr((string) $stream, $firstValue);
 
         if (count($index) % 2 !== 0) {

--- a/src/Infrastructure/PdfCore/Service/PdfObjectReader.php
+++ b/src/Infrastructure/PdfCore/Service/PdfObjectReader.php
@@ -13,13 +13,15 @@ final class PdfObjectReader
 {
     public function objectFromBuffer(string $buffer, int|string|null $expectedObjId, int $offset = 0, int &$offsetEnd = 0): PDFObject
     {
-        if (preg_match('/(\d+)\s+(\d+)\s+obj/ms', $buffer, $matches, 0, $offset) !== 1) {
+        $headerMatchedAt = strpos($buffer, 'obj', $offset);
+        if (preg_match('/(\d+)\s+(\d+)\s+obj/ms', $buffer, $matches, PREG_OFFSET_CAPTURE, $offset) !== 1) {
             throw new PdfCoreParsingException('Invalid object definition: '.$expectedObjId);
         }
 
-        $foundObjHeader = $matches[0];
-        $foundObjId = (int) $matches[1];
-        $foundObjGeneration = (int) $matches[2];
+        $foundObjHeader = $matches[0][0];
+        $foundObjHeaderOffset = $matches[0][1];
+        $foundObjId = (int) $matches[1][0];
+        $foundObjGeneration = (int) $matches[2][0];
 
         if ($expectedObjId === null) {
             $expectedObjId = $foundObjId;
@@ -34,18 +36,30 @@ final class PdfObjectReader
             ));
         }
 
-        $offset += strlen($foundObjHeader);
+        $offset = $foundObjHeaderOffset + strlen($foundObjHeader);
 
         $parser = new ObjectParser;
         $stream = new StreamReader($buffer, $offset);
         $objParsed = $parser->parse($stream);
 
-        switch ($parser->currentToken()) {
-            case ObjectParser::T_STREAM_BEGIN:
-            case ObjectParser::T_OBJECT_END:
+        // Skip any trailing comments or stray tokens between >> and stream/endobj.
+        $skipLimit = 32;
+        while ($skipLimit-- > 0) {
+            $tok = $parser->currentToken();
+            if ($tok === ObjectParser::T_STREAM_BEGIN || $tok === ObjectParser::T_OBJECT_END) {
                 break;
-            default:
-                throw new PdfCoreParsingException('Malformed object');
+            }
+            if ($tok === ObjectParser::T_COMMENT
+                || $tok === ObjectParser::T_LIST_START
+                || $tok === ObjectParser::T_LIST_END
+                || $tok === ObjectParser::T_SIMPLE
+                || $tok === ObjectParser::T_FIELD) {
+                $parser->advanceToken();
+
+                continue;
+            }
+
+            throw new PdfCoreParsingException('Malformed object');
         }
 
         $offsetEnd = $stream->getPosition();

--- a/src/Infrastructure/PdfCore/Xref/Service/XRef14Parser.php
+++ b/src/Infrastructure/PdfCore/Xref/Service/XRef14Parser.php
@@ -16,8 +16,12 @@ final class XRef14Parser
      * @throws PdfCoreParsingException
      * @throws PdfCoreStructureException
      */
-    public function parse(string $buffer, int $xrefPosition): XrefParseResult
+    public function parse(string $buffer, int $xrefPosition, array $visitedPositions = []): XrefParseResult
     {
+        if ($xrefPosition > strlen($buffer)) {
+            throw new PdfCoreParsingException('Xref position '.$xrefPosition.' is beyond end of file');
+        }
+
         $trailerPosition = strpos($buffer, 'trailer', $xrefPosition);
         if ($trailerPosition === false) {
             throw new PdfCoreParsingException('Trailer tag not found after xref at position '.$xrefPosition);
@@ -32,8 +36,10 @@ final class XRef14Parser
             ->withTrailerPosition($trailerPosition)
             ->getTrailer();
 
+        $visitedPositions[$xrefPosition] = true;
+
         if (isset($trailer['Prev'])) {
-            $xrefTable = $this->mergePreviousTables($buffer, $trailer, $version, $xrefTable);
+            $xrefTable = $this->mergePreviousTables($buffer, $trailer, $version, $xrefTable, $visitedPositions);
         }
 
         return new XrefParseResult($xrefTable, $trailer, $version);
@@ -47,15 +53,28 @@ final class XRef14Parser
      */
     private function parseEntries(string $xrefText, int $xrefPosition): array
     {
-        $lineSeparator = "\r\n";
-        $line = strtok($xrefText, $lineSeparator);
-        while ($line !== false && trim($line) === '') {
-            $line = strtok($lineSeparator);
+        // Scan forward to find the 'xref' keyword — some generators have startxref pointing
+        // slightly before it (e.g. into trailing 'endobj'), or 'xref' may share a line with
+        // preceding tokens like 'endobj xref'.
+        $xrefKeywordOffset = false;
+        $searchOffset = 0;
+        while (($pos = strpos($xrefText, 'xref', $searchOffset)) !== false) {
+            // Verify 'xref' is followed by whitespace or end of string (not part of a longer word).
+            $after = $pos + 4;
+            if ($after >= strlen($xrefText) || ctype_space($xrefText[$after])) {
+                $xrefKeywordOffset = $pos;
+                break;
+            }
+            $searchOffset = $pos + 1;
         }
 
-        if ($line === false || trim($line) !== 'xref') {
+        if ($xrefKeywordOffset === false) {
             throw new PdfCoreParsingException('Xref tag not found at position '.$xrefPosition);
         }
+
+        // Use only the part of xrefText starting after the 'xref' keyword.
+        $xrefText = substr($xrefText, $xrefKeywordOffset + 4);
+        $lineSeparator = "\r\n";
 
         $currentObjectId = 0;
         $remainingObjectsInSection = 0;
@@ -63,12 +82,11 @@ final class XRef14Parser
         $sawSectionHeader = false;
         $parsedEntries = 0;
 
-        while (($line = strtok($lineSeparator)) !== false) {
-            if (preg_match('/(\d+) (\d+)$/', $line, $matches) === 1) {
-                if ($remainingObjectsInSection > 0) {
-                    throw new PdfCoreParsingException('Malformed xref at position '.$xrefPosition);
-                }
-
+        // Initialize strtok; use a for-loop pattern to avoid strtok re-initialization issues.
+        for ($line = strtok($xrefText, $lineSeparator); $line !== false; $line = strtok($lineSeparator)) {
+            if (preg_match('/^\s*(\d+)\s+(\d+)\s*$/', $line, $matches) === 1) {
+                // Start a new section. If the previous section still had declared entries
+                // outstanding, accept the mismatch (common in non-conforming generators).
                 $sawSectionHeader = true;
                 $currentObjectId = (int) $matches[1];
                 $remainingObjectsInSection = (int) $matches[2];
@@ -81,7 +99,8 @@ final class XRef14Parser
             }
 
             if ($remainingObjectsInSection === 0) {
-                throw new PdfCoreParsingException('Unexpected entry for xref: '.$line);
+                // Entry appears outside any declared section; skip tolerantly.
+                continue;
             }
 
             $this->applyEntry($xrefTable, $currentObjectId, (int) $matches[1], (int) $matches[2], $matches[3]);
@@ -90,7 +109,8 @@ final class XRef14Parser
             $remainingObjectsInSection--;
         }
 
-        if (! $sawSectionHeader || $parsedEntries === 0) {
+        // An empty xref (0 0 section header, no entries) is valid for incremental updates.
+        if (! $sawSectionHeader) {
             throw new PdfCoreParsingException('Malformed xref at position '.$xrefPosition);
         }
 
@@ -115,10 +135,8 @@ final class XRef14Parser
         }
 
         if ($operation === 'n') {
-            if ($generation !== 0) {
-                throw new PdfCoreStructureException('Objects of non-zero generation are not supported.');
-            }
-
+            // Non-zero generations indicate reused object slots (after free/reuse cycles).
+            // We store the entry by offset; the generation field is not used by the signer.
             $xrefTable[$objectId] = $offset;
         }
     }
@@ -130,7 +148,7 @@ final class XRef14Parser
      * @throws PdfCoreParsingException
      * @throws PdfCoreStructureException
      */
-    private function mergePreviousTables(string $buffer, PDFValue $trailer, string $version, array $currentTable): array
+    private function mergePreviousTables(string $buffer, PDFValue $trailer, string $version, array $currentTable, array $visitedPositions = []): array
     {
         $prev = $trailer['Prev'] ?? null;
         $prevPosition = $prev->val();
@@ -138,7 +156,12 @@ final class XRef14Parser
             throw new PdfCoreStructureException('Invalid trailer: Prev must be numeric.');
         }
 
-        $previous = $this->parse($buffer, (int) $prevPosition);
+        if (isset($visitedPositions[(int) $prevPosition])) {
+            // Circular Prev chain detected — stop recursion.
+            return $currentTable;
+        }
+
+        $previous = $this->parse($buffer, (int) $prevPosition, $visitedPositions);
 
         foreach ($previous->table as $objectId => $offset) {
             if (! isset($currentTable[$objectId])) {

--- a/src/Infrastructure/PdfCore/Xref/Service/XRef15Parser.php
+++ b/src/Infrastructure/PdfCore/Xref/Service/XRef15Parser.php
@@ -12,7 +12,7 @@ use SignerPHP\Infrastructure\PdfCore\Xref\XrefParseResult;
 
 final class XRef15Parser
 {
-    public function parse(PdfDocument $pdfDocument, int $xrefPosition): XrefParseResult
+    public function parse(PdfDocument $pdfDocument, int $xrefPosition, array $visitedPositions = []): XrefParseResult
     {
         $xrefObject = $pdfDocument->findObjectAtOffset($xrefPosition);
 
@@ -43,6 +43,8 @@ final class XRef15Parser
             throw new PdfCoreStructureException('Invalid indexes of xref table');
         }
 
+        $visitedPositions[$xrefPosition] = true;
+
         $xrefTable = [];
         if (isset($xrefObject['Prev'])) {
             $prev = $xrefObject['Prev']->asIntOrNull();
@@ -50,7 +52,9 @@ final class XRef15Parser
                 throw new PdfCoreStructureException('Invalid reference to a previous xref table');
             }
 
-            $xrefTable = $this->parse($pdfDocument, $prev)->table;
+            if (! isset($visitedPositions[$prev])) {
+                $xrefTable = $this->parsePreviousTable($pdfDocument, $prev, $visitedPositions);
+            }
         }
 
         $reader = new StreamReader($stream);
@@ -94,9 +98,7 @@ final class XRef15Parser
 
                 return;
             case 1:
-                if ($fieldThree !== 0) {
-                    throw new PdfCoreStructureException('Objects of non-zero generation are not supported.');
-                }
+                // fieldThree is the generation number; non-zero is allowed (reused slot).
                 $xrefTable[$objectId] = $fieldTwo;
 
                 return;
@@ -126,5 +128,18 @@ final class XRef15Parser
         }
 
         return $value;
+    }
+
+    /** @return array<int, int|array{stmoid:int,pos:int}|null> */
+    private function parsePreviousTable(PdfDocument $pdfDocument, int $prev, array $visitedPositions): array
+    {
+        $raw = $pdfDocument->getBuffer()->raw();
+        $trimmed = ltrim(substr($raw, $prev, 64));
+
+        if (preg_match('/^\d+\s+\d+\s+obj\b/', $trimmed) === 1) {
+            return $this->parse($pdfDocument, $prev, $visitedPositions)->table;
+        }
+
+        return (new XRef14Parser)->parse($raw, $prev, $visitedPositions)->table;
     }
 }

--- a/src/Infrastructure/PdfCore/Xref/Xref.php
+++ b/src/Infrastructure/PdfCore/Xref/Xref.php
@@ -86,7 +86,29 @@ class Xref
 
     private function isCrossReferenceStream(): bool
     {
-        return strpos($this->pdfDocument->getBuffer()->raw(), 'trailer', $this->xrefPosition) === false;
+        $raw = $this->pdfDocument->getBuffer()->raw();
+        if ($this->xrefPosition > strlen($raw)) {
+            return false;
+        }
+
+        // Look at what is actually at the xref position.
+        // Skip whitespace, then check whether we see an object header (N G obj) — which
+        // indicates a cross-reference stream — or the literal 'xref' keyword.
+        $snippet = substr($raw, $this->xrefPosition, 64);
+        $trimmed = ltrim($snippet);
+
+        // If trimmed content looks like an object definition (digits … obj), it's a stream.
+        if (preg_match('/^\d+\s+\d+\s+obj\b/', $trimmed) === 1) {
+            return true;
+        }
+
+        // If trimmed content starts with 'xref', it's a cross-reference table.
+        if (strncmp($trimmed, 'xref', 4) === 0) {
+            return false;
+        }
+
+        // Fallback: use the old heuristic (no 'trailer' keyword after this position → stream).
+        return strpos($raw, 'trailer', $this->xrefPosition) === false;
     }
 
     private function contentBuilder(): XrefContentBuilder

--- a/tests/Infrastructure/PdfCore/ObjectParserTest.php
+++ b/tests/Infrastructure/PdfCore/ObjectParserTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SignerPHP\Tests\Infrastructure\PdfCore;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use SignerPHP\Infrastructure\PdfCore\ObjectParser;
+use SignerPHP\Infrastructure\PdfCore\PdfValue\PDFValueObject;
+
+final class ObjectParserTest extends TestCase
+{
+    #[DataProvider('tolerantDictionaryCases')]
+    public function test_parse_string_tolerates_malformed_but_recoverable_dictionary_tokens(
+        string $input,
+        bool $expectsType,
+        ?string $expectedType,
+        int $expectedPagesOid
+    ): void {
+        $parsed = (new ObjectParser)->parseString($input);
+        self::assertInstanceOf(PDFValueObject::class, $parsed);
+
+        if ($expectsType) {
+            self::assertSame($expectedType, $parsed['Type']->val());
+        } else {
+            self::assertFalse($parsed->has('Type'));
+        }
+
+        self::assertSame($expectedPagesOid, $parsed['Pages']->asObjectReferenceOrNull());
+    }
+
+    /** @return array<string, array{string, bool, string|null, int}> */
+    public static function tolerantDictionaryCases(): array
+    {
+        return [
+            'stray list-end between valid fields' => [
+                '<< /Type /Catalog ] /Pages 2 0 R >>',
+                true,
+                'Catalog',
+                2,
+            ],
+            'field value resolved as null due to list boundary' => [
+                '<< /Type ] /Pages 2 0 R >>',
+                false,
+                null,
+                2,
+            ],
+            'comment between dictionary fields' => [
+                "<< /Type /Catalog\n% comment from malformed producer\n/Pages 2 0 R >>",
+                true,
+                'Catalog',
+                2,
+            ],
+            'leading stray tokens and comment before valid fields' => [
+                "<< ] % producer glitch\n/Type /Catalog /Pages 2 0 R >>",
+                true,
+                'Catalog',
+                2,
+            ],
+            'multiple comments and stray list-end markers are skipped' => [
+                "<< % first\n] % second\n/Type /Catalog ]\n/Pages 2 0 R >>",
+                true,
+                'Catalog',
+                2,
+            ],
+        ];
+    }
+}

--- a/tests/Infrastructure/PdfCore/PDFObjectTest.php
+++ b/tests/Infrastructure/PdfCore/PDFObjectTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SignerPHP\Tests\Infrastructure\PdfCore;
+
+use PHPUnit\Framework\TestCase;
+use SignerPHP\Infrastructure\PdfCore\PDFObject;
+use SignerPHP\Infrastructure\PdfCore\PdfValue\PDFValueList;
+use SignerPHP\Infrastructure\PdfCore\PdfValue\PDFValueSimple;
+
+final class PDFObjectTest extends TestCase
+{
+    public function test_get_stream_decodes_flate_filter_declared_as_single_item_array(): void
+    {
+        $object = new PDFObject(1, [
+            'Filter' => new PDFValueList([
+                new PDFValueSimple('FlateDecode'),
+            ]),
+        ]);
+
+        $payload = gzcompress('abc');
+        self::assertIsString($payload);
+        $object->setStream($payload);
+
+        self::assertSame('abc', $object->getStream(false));
+    }
+}

--- a/tests/Infrastructure/PdfCore/PageInfoTest.php
+++ b/tests/Infrastructure/PdfCore/PageInfoTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SignerPHP\Tests\Infrastructure\PdfCore;
+
+use PHPUnit\Framework\TestCase;
+use SignerPHP\Infrastructure\PdfCore\PageInfo;
+use SignerPHP\Infrastructure\PdfCore\PdfDocument;
+use SignerPHP\Infrastructure\PdfCore\PDFObject;
+use SignerPHP\Infrastructure\PdfCore\PdfValue\PDFValueList;
+use SignerPHP\Infrastructure\PdfCore\PdfValue\PDFValueObject;
+use SignerPHP\Infrastructure\PdfCore\PdfValue\PDFValueReference;
+use SignerPHP\Infrastructure\PdfCore\PdfValue\PDFValueSimple;
+
+final class PageInfoTest extends TestCase
+{
+    public function test_acquire_pages_info_skips_cycles_in_page_tree(): void
+    {
+        $document = new PdfDocument;
+        $document->setTrailerObject(new PDFValueObject([
+            'Root' => new PDFValueReference(1),
+        ]));
+        $document->addObject(new PDFObject(1, [
+            'Type' => '/Catalog',
+            'Pages' => new PDFValueReference(2),
+        ]));
+        $document->addObject(new PDFObject(2, [
+            'Type' => '/Pages',
+            'Kids' => new PDFValueList([
+                new PDFValueReference(3),
+            ]),
+        ]));
+        $document->addObject(new PDFObject(3, [
+            'Type' => '/Pages',
+            'Kids' => new PDFValueList([
+                new PDFValueReference(2),
+                new PDFValueReference(4),
+            ]),
+        ]));
+        $document->addObject(new PDFObject(4, [
+            'Type' => '/Page',
+            'MediaBox' => new PDFValueList([
+                new PDFValueSimple(0),
+                new PDFValueSimple(0),
+                new PDFValueSimple(595),
+                new PDFValueSimple(842),
+            ]),
+        ]));
+
+        $pageInfo = PageInfo::new()
+            ->withPdfDocument($document)
+            ->acquirePagesInfo();
+
+        self::assertNotNull($pageInfo->getPage(0));
+        self::assertNull($pageInfo->getPage(1));
+        self::assertSame(
+            [0, 0, 595, 842],
+            array_map(
+                static fn (PDFValueSimple $value): int => $value->asIntOrNull() ?? -1,
+                $pageInfo->getPageSize(0) ?? []
+            )
+        );
+    }
+}

--- a/tests/Infrastructure/PdfCore/Service/ObjectStreamResolverTest.php
+++ b/tests/Infrastructure/PdfCore/Service/ObjectStreamResolverTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SignerPHP\Tests\Infrastructure\PdfCore\Service;
+
+use PHPUnit\Framework\TestCase;
+use SignerPHP\Infrastructure\PdfCore\PdfDocument;
+use SignerPHP\Infrastructure\PdfCore\PDFObject;
+use SignerPHP\Infrastructure\PdfCore\Service\ObjectStreamResolver;
+
+final class ObjectStreamResolverTest extends TestCase
+{
+    public function test_resolve_from_object_stream_accepts_whitespace_separated_index(): void
+    {
+        $index = "20\t0\n";
+        $objectStream = new PDFObject(99, [
+            'Type' => '/ObjStm',
+            'First' => strlen($index),
+            'N' => 1,
+        ]);
+        $objectStream->setStream($index.'<< /Type /Catalog >>');
+
+        $document = new class($objectStream) extends PdfDocument
+        {
+            public function __construct(private readonly PDFObject $objectStream) {}
+
+            public function findObject(int $oid): ?PDFObject
+            {
+                return $oid === $this->objectStream->getOid() ? $this->objectStream : null;
+            }
+        };
+
+        $resolved = (new ObjectStreamResolver)->resolveFromObjectStream($document, 99, 0, 20);
+
+        self::assertSame(20, $resolved->getOid());
+        self::assertSame('Catalog', $resolved['Type']->val());
+    }
+}

--- a/tests/Infrastructure/PdfCore/Service/PdfObjectReaderTest.php
+++ b/tests/Infrastructure/PdfCore/Service/PdfObjectReaderTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SignerPHP\Tests\Infrastructure\PdfCore\Service;
+
+use PHPUnit\Framework\TestCase;
+use SignerPHP\Infrastructure\PdfCore\Service\PdfObjectReader;
+
+final class PdfObjectReaderTest extends TestCase
+{
+    public function test_object_from_buffer_skips_stray_list_tokens_before_endobj(): void
+    {
+        $reader = new PdfObjectReader;
+        $buffer = "1 0 obj\n<< /Type /Catalog >>\n]\n[\nendobj\n";
+        $offsetEnd = 0;
+
+        $object = $reader->objectFromBuffer($buffer, 1, 0, $offsetEnd);
+
+        self::assertSame(1, $object->getOid());
+        self::assertSame('Catalog', $object['Type']->val());
+        self::assertGreaterThan(0, $offsetEnd);
+    }
+
+    public function test_object_from_buffer_accepts_offset_pointing_before_object_header(): void
+    {
+        $reader = new PdfObjectReader;
+        $buffer = "\n22 0 obj\n<< /Type /XRef /Length 0 >>\nstream\nendstream\nendobj\n";
+        $offsetEnd = 0;
+
+        $object = $reader->objectFromBuffer($buffer, 22, 0, $offsetEnd);
+
+        self::assertSame(22, $object->getOid());
+        self::assertSame('XRef', $object['Type']->val());
+        self::assertGreaterThan(0, $offsetEnd);
+    }
+}

--- a/tests/Infrastructure/PdfCore/Xref/Service/XRef14ParserTest.php
+++ b/tests/Infrastructure/PdfCore/Xref/Service/XRef14ParserTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SignerPHP\Tests\Infrastructure\PdfCore\Xref\Service;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use SignerPHP\Infrastructure\PdfCore\Xref\Service\XRef14Parser;
+
+final class XRef14ParserTest extends TestCase
+{
+    #[DataProvider('parseFailureCases')]
+    public function test_parse_throws_for_invalid_xref_inputs(string $buffer, int $xrefPosition, string $expectedMessage): void
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        (new XRef14Parser)->parse($buffer, $xrefPosition);
+    }
+
+    #[DataProvider('parseSuccessCases')]
+    public function test_parse_handles_supported_xref_variants(
+        string $buffer,
+        int $xrefPosition,
+        int $expectedObjectId,
+        ?int $expectedOffset
+    ): void {
+        $result = (new XRef14Parser)->parse($buffer, $xrefPosition);
+
+        if ($expectedOffset === null) {
+            self::assertSame([], $result->table);
+
+            return;
+        }
+
+        self::assertSame($expectedOffset, $result->table[$expectedObjectId]);
+    }
+
+    /** @return array<string, array{string, int, int, int|null}> */
+    public static function parseSuccessCases(): array
+    {
+        return [
+            'prefixed chunk ending with xref keyword' => [
+                "endobj xref\n0 1\n0000000010 00000 n \ntrailer\n<< /Size 1 >>\nstartxref\n0\n%%EOF\n",
+                0,
+                0,
+                10,
+            ],
+            'skip non keyword xref substring and use valid tag' => [
+                "prefix-xref-tag xref\n0 1\n0000000042 00000 n \ntrailer\n<< /Size 1 >>\nstartxref\n0\n%%EOF\n",
+                0,
+                0,
+                42,
+            ],
+            'accept empty zero-zero section' => [
+                "xref\n0 0\ntrailer\n<< /Size 1 >>\nstartxref\n0\n%%EOF\n",
+                0,
+                0,
+                null,
+            ],
+            'stop on circular prev chain' => [
+                "xref\n0 1\n0000000010 00000 n \ntrailer\n<< /Size 1 /Prev 0 >>\nstartxref\n0\n%%EOF\n",
+                0,
+                0,
+                10,
+            ],
+            'section header with extra spacing still parses' => [
+                "xref\n  0   1 \n0000000015 00000 n \ntrailer\n<< /Size 1 >>\nstartxref\n0\n%%EOF\n",
+                0,
+                0,
+                15,
+            ],
+        ];
+    }
+
+    /** @return array<string, array{string, int, string}> */
+    public static function parseFailureCases(): array
+    {
+        $validBuffer = "xref\n0 1\n0000000010 00000 n \ntrailer\n<< /Size 1 >>\n";
+
+        return [
+            'xref position beyond end of file' => [$validBuffer, strlen($validBuffer) + 1, 'beyond end of file'],
+            'xref tag missing at provided position' => [
+                "no-tag-here\ntrailer\n<< /Size 1 >>\nstartxref\n0\n%%EOF\n",
+                0,
+                'Xref tag not found at position 0',
+            ],
+        ];
+    }
+}

--- a/tests/Infrastructure/PdfCore/Xref/Service/XRef15ParserTest.php
+++ b/tests/Infrastructure/PdfCore/Xref/Service/XRef15ParserTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SignerPHP\Tests\Infrastructure\PdfCore\Xref\Service;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use SignerPHP\Infrastructure\PdfCore\PdfDocument;
+use SignerPHP\Infrastructure\PdfCore\PDFObject;
+use SignerPHP\Infrastructure\PdfCore\PdfValue\PDFValueList;
+use SignerPHP\Infrastructure\PdfCore\PdfValue\PDFValueSimple;
+use SignerPHP\Infrastructure\PdfCore\Xref\Service\XRef15Parser;
+
+final class XRef15ParserTest extends TestCase
+{
+    public function test_parse_stops_on_circular_prev_reference(): void
+    {
+        $stream = chr(1).pack('n', 123).chr(0);
+        $object = $this->xrefObject($stream, [1, 2, 1], [5, 1], 10);
+        $object['Prev'] = 100;
+
+        $document = $this->documentAtPositions([100 => $object]);
+
+        $result = (new XRef15Parser)->parse($document, 100);
+
+        self::assertSame(123, $result->table[5]);
+    }
+
+    #[DataProvider('previousTableMergeCases')]
+    public function test_parse_merges_previous_tables_and_keeps_expected_entries(
+        string $previousKind,
+        int $currentOffset,
+        int $currentObjectId,
+        int $currentEntryOffset,
+        int $previousOffset,
+        int $previousObjectId,
+        int $previousEntryOffset,
+        int $expectedCurrentOffset
+    ): void {
+        $current = $this->xrefObject(chr(1).pack('n', $currentEntryOffset).chr(0), [1, 2, 1], [$currentObjectId, 1], 8);
+        $current['Prev'] = $previousOffset;
+
+        if ($previousKind === 'classic') {
+            $classicXref = sprintf(
+                "xref\n%d 1\n%010d 00000 n \ntrailer\n<< /Size 8 >>\nstartxref\n0\n%%EOF\n",
+                $previousObjectId,
+                $previousEntryOffset
+            );
+
+            $document = $this->documentAtPositions([
+                $currentOffset => $current,
+            ], $classicXref.str_repeat(' ', max(0, $currentOffset - strlen($classicXref))).'2 0 obj');
+        } else {
+            $previous = $this->xrefObject(chr(1).pack('n', $previousEntryOffset).chr(0), [1, 2, 1], [$previousObjectId, 1], 8);
+            $document = $this->documentAtPositions([
+                $currentOffset => $current,
+                $previousOffset => $previous,
+            ]);
+        }
+
+        $result = (new XRef15Parser)->parse($document, $currentOffset);
+
+        if ($previousObjectId !== $currentObjectId) {
+            self::assertSame($previousEntryOffset, $result->table[$previousObjectId]);
+        }
+        self::assertSame($expectedCurrentOffset, $result->table[$currentObjectId]);
+    }
+
+    /** @return array<string, array{string, int, int, int, int, int, int, int}> */
+    public static function previousTableMergeCases(): array
+    {
+        return [
+            'merges previous classic xref table' => ['classic', 100, 2, 77, 0, 1, 33, 77],
+            'merges previous xref stream table' => ['stream', 100, 2, 77, 200, 1, 33, 77],
+            'current entry overrides same object from previous table' => ['stream', 100, 2, 77, 200, 2, 33, 77],
+            'current entry overrides same object from previous classic table' => ['classic', 100, 2, 77, 0, 2, 33, 77],
+        ];
+    }
+
+    private function xrefObject(string $stream, array $w, array $index, int $size): PDFObject
+    {
+        $wValues = array_map(static fn (int $v): PDFValueSimple => new PDFValueSimple($v), $w);
+        $indexValues = array_map(static fn (int $v): PDFValueSimple => new PDFValueSimple($v), $index);
+
+        $object = new PDFObject(1, [
+            'Type' => '/XRef',
+            'W' => new PDFValueList($wValues),
+            'Index' => new PDFValueList($indexValues),
+            'Size' => $size,
+        ]);
+        $object->setStream($stream);
+
+        return $object;
+    }
+
+    /** @param array<int, PDFObject> $objectsByPosition */
+    private function documentAtPositions(array $objectsByPosition, string $buffer = ''): PdfDocument
+    {
+        if ($buffer === '') {
+            ksort($objectsByPosition);
+            $buffer = '';
+            $cursor = 0;
+            foreach (array_keys($objectsByPosition) as $offset) {
+                if ($offset > $cursor) {
+                    $buffer .= str_repeat(' ', $offset - $cursor);
+                }
+                $buffer .= '1 0 obj';
+                $cursor = strlen($buffer);
+            }
+        }
+
+        return new class($objectsByPosition, $buffer) extends PdfDocument
+        {
+            /** @param array<int, PDFObject> $objectsByPosition */
+            public function __construct(private readonly array $objectsByPosition, string $buffer)
+            {
+                $this->setBufferFromString($buffer);
+            }
+
+            public function findObjectAtOffset(int $objectOffset, ?int $expectedOid = null): PDFObject
+            {
+                return $this->objectsByPosition[$objectOffset];
+            }
+        };
+    }
+}

--- a/tests/Infrastructure/PdfCore/Xref/XrefTest.php
+++ b/tests/Infrastructure/PdfCore/Xref/XrefTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SignerPHP\Tests\Infrastructure\PdfCore\Xref;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use SignerPHP\Infrastructure\PdfCore\PdfDocument;
+use SignerPHP\Infrastructure\PdfCore\Xref\Xref;
+
+final class XrefTest extends TestCase
+{
+    #[DataProvider('parseSuccessCases')]
+    public function test_parse_routes_to_expected_parser_and_returns_expected_table(
+        string $buffer,
+        int $xrefPosition,
+        string $expectedVersion,
+        int $expectedObjectId,
+        int $expectedOffset
+    ): void {
+        $document = new PdfDocument;
+        $document->setBufferFromString($buffer);
+
+        $result = Xref::new()
+            ->withPdfDocument($document)
+            ->withXrefPosition($xrefPosition)
+            ->parse();
+
+        self::assertSame($expectedVersion, $result->minimumPdfVersion);
+        self::assertSame($expectedOffset, $result->table[$expectedObjectId]);
+    }
+
+    #[DataProvider('parseFailureCases')]
+    public function test_parse_throws_expected_exception_for_ambiguous_or_invalid_cases(
+        string $buffer,
+        int $xrefPosition,
+        string $expectedMessage
+    ): void {
+        $document = new PdfDocument;
+        $document->setBufferFromString($buffer);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage($expectedMessage);
+
+        Xref::new()
+            ->withPdfDocument($document)
+            ->withXrefPosition($xrefPosition)
+            ->parse();
+    }
+
+    /** @return array<string, array{string, int, string, int, int}> */
+    public static function parseSuccessCases(): array
+    {
+        $streamEntry = chr(1).chr(10).chr(0);
+
+        return [
+            'xref stream at xref position' => [
+                "1 0 obj\n"
+                ."<< /Type /XRef /Length 3 /W [1 1 1] /Size 2 /Index [1 1] >>\n"
+                ."stream\n"
+                .$streamEntry."\n"
+                ."endstream\n"
+                ."endobj\n",
+                0,
+                '1.5',
+                1,
+                10,
+            ],
+            'xref stream when xref position points before object header' => [
+                "\n1 0 obj\n"
+                ."<< /Type /XRef /Length 3 /W [1 1 1] /Size 2 /Index [1 1] >>\n"
+                ."stream\n"
+                .$streamEntry."\n"
+                ."endstream\n"
+                ."endobj\n",
+                0,
+                '1.5',
+                1,
+                10,
+            ],
+            'classic xref keyword at xref position' => [
+                "xref\n0 2\n0000000000 65535 f \n0000000010 00000 n \ntrailer\n<< /Size 2 >>\nstartxref\n0\n%%EOF\n",
+                0,
+                '1.4',
+                1,
+                10,
+            ],
+            'classic xref with prefixed whitespace before keyword' => [
+                "  \n xref\n0 2\n0000000000 65535 f \n0000000010 00000 n \ntrailer\n<< /Size 2 >>\nstartxref\n0\n%%EOF\n",
+                0,
+                '1.4',
+                1,
+                10,
+            ],
+        ];
+    }
+
+    /** @return array<string, array{string, int, string}> */
+    public static function parseFailureCases(): array
+    {
+        return [
+            'xref position beyond end of file' => [
+                "xref\n0 1\n0000000000 65535 f \ntrailer",
+                10_000,
+                'beyond end of file',
+            ],
+            'stream fallback for ambiguous content without trailer' => [
+                "garbage-at-start\n1 0 obj\n<< /Type /Catalog >>\nendobj\n",
+                0,
+                'Invalid xref table',
+            ],
+            'classic fallback for ambiguous content with trailer' => [
+                "garbage-at-start\ntrailer\n<< /Size 1 >>\n",
+                0,
+                'Xref tag not found at position 0',
+            ],
+        ];
+    }
+}

--- a/tests/Unit/XRef14ParserTest.php
+++ b/tests/Unit/XRef14ParserTest.php
@@ -25,7 +25,7 @@ final class XRef14ParserTest extends TestCase
 
     public function test_parse_throws_when_xref_tag_is_missing_at_position(): void
     {
-        $buffer = "notxref\ntrailer\n<< /Size 1 >>\nstartxref\n0\n%%EOF\n";
+        $buffer = "no-tag-here\ntrailer\n<< /Size 1 >>\nstartxref\n0\n%%EOF\n";
 
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Xref tag not found at position 0');
@@ -59,31 +59,31 @@ final class XRef14ParserTest extends TestCase
         self::assertSame(10, $result->table[0]);
     }
 
-    public function test_parse_throws_when_section_header_appears_before_consuming_entries(): void
+    public function test_parse_accepts_section_header_appearing_before_previous_section_is_fully_consumed(): void
     {
         $buffer = "xref\n0 2\n1 1\n0000000001 00000 n \ntrailer\n<< /Size 2 >>\nstartxref\n0\n%%EOF\n";
 
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Malformed xref at position 0');
-        (new XRef14Parser)->parse($buffer, 0);
+        $result = (new XRef14Parser)->parse($buffer, 0);
+
+        self::assertSame(1, $result->table[1]);
     }
 
-    public function test_parse_throws_when_entry_appears_without_open_section(): void
+    public function test_parse_skips_entry_that_appears_outside_declared_section(): void
     {
         $buffer = "xref\n0 0\n0000000001 00000 n \ntrailer\n<< /Size 1 >>\nstartxref\n0\n%%EOF\n";
 
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Unexpected entry for xref');
-        (new XRef14Parser)->parse($buffer, 0);
+        $result = (new XRef14Parser)->parse($buffer, 0);
+
+        self::assertSame([], $result->table);
     }
 
-    public function test_parse_throws_for_non_zero_generation_in_in_use_entry(): void
+    public function test_parse_keeps_in_use_entry_with_non_zero_generation(): void
     {
         $buffer = "xref\n1 1\n0000000001 00001 n \ntrailer\n<< /Size 2 >>\nstartxref\n0\n%%EOF\n";
 
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Objects of non-zero generation are not supported.');
-        (new XRef14Parser)->parse($buffer, 0);
+        $result = (new XRef14Parser)->parse($buffer, 0);
+
+        self::assertSame(1, $result->table[1]);
     }
 
     public function test_parse_throws_when_prev_is_not_numeric(): void
@@ -114,12 +114,12 @@ final class XRef14ParserTest extends TestCase
         self::assertSame(10, $result->table[1]);
     }
 
-    public function test_parse_throws_when_section_has_no_valid_entries(): void
+    public function test_parse_accepts_section_without_valid_entries_when_header_exists(): void
     {
         $buffer = "xref\n0 1\nnot-an-entry\ntrailer\n<< /Size 1 >>\nstartxref\n0\n%%EOF\n";
 
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Malformed xref at position 0');
-        (new XRef14Parser)->parse($buffer, 0);
+        $result = (new XRef14Parser)->parse($buffer, 0);
+
+        self::assertSame([], $result->table);
     }
 }

--- a/tests/Unit/XRef15ParserTest.php
+++ b/tests/Unit/XRef15ParserTest.php
@@ -63,16 +63,15 @@ final class XRef15ParserTest extends TestCase
         self::assertSame(77, $result->table[2]);
     }
 
-    public function test_parse_throws_when_generation_is_non_zero_for_type_one(): void
+    public function test_parse_keeps_offset_entry_when_generation_is_non_zero_for_type_one(): void
     {
         $stream = chr(1).pack('n', 123).chr(1);
         $object = $this->xrefObject($stream, [1, 2, 1], [5, 1], 10);
         $document = $this->documentAtPositions([100 => $object]);
 
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Objects of non-zero generation are not supported.');
+        $result = (new XRef15Parser)->parse($document, 100);
 
-        (new XRef15Parser)->parse($document, 100);
+        self::assertSame(123, $result->table[5]);
     }
 
     public function test_parse_throws_for_invalid_entry_type(): void
@@ -161,12 +160,28 @@ final class XRef15ParserTest extends TestCase
     }
 
     /** @param array<int, PDFObject> $objectsByPosition */
-    private function documentAtPositions(array $objectsByPosition): PdfDocument
+    private function documentAtPositions(array $objectsByPosition, string $buffer = ''): PdfDocument
     {
-        return new class($objectsByPosition) extends PdfDocument
+        if ($buffer === '') {
+            ksort($objectsByPosition);
+            $buffer = '';
+            $cursor = 0;
+            foreach (array_keys($objectsByPosition) as $offset) {
+                if ($offset > $cursor) {
+                    $buffer .= str_repeat(' ', $offset - $cursor);
+                }
+                $buffer .= '1 0 obj';
+                $cursor = strlen($buffer);
+            }
+        }
+
+        return new class($objectsByPosition, $buffer) extends PdfDocument
         {
             /** @param array<int, PDFObject> $objectsByPosition */
-            public function __construct(private readonly array $objectsByPosition) {}
+            public function __construct(private readonly array $objectsByPosition, string $buffer)
+            {
+                $this->setBufferFromString($buffer);
+            }
 
             public function objectFromString(int|string|null $expectedObjId, int $offset = 0, int &$offsetEnd = 0): PDFObject
             {


### PR DESCRIPTION
## Summary
This PR hardens PDF core parsing to prevent failures on malformed and hybrid documents.

## Fixed error classes
- Null dictionary field values now fail fast with explicit exceptions instead of propagating invalid state.
- Object/header offset resolution is more tolerant to malformed structures and avoids incorrect object reads.
- XRef parsing now handles hybrid Prev chains more safely and reduces ambiguous/fallback parse failures.