### PR TITLE
fix(pdf-core): harden FlateDecode prefix tolerance and xref/object offset recovery

### DIFF
--- a/src/Infrastructure/PdfCore/PDFObject.php
+++ b/src/Infrastructure/PdfCore/PDFObject.php
@@ -202,28 +202,46 @@ endstream
      */
     private static function inflateFlateStream(string $stream): string
     {
-        $b0 = strlen($stream) > 1 ? ord($stream[0]) : -1;
-        $b1 = strlen($stream) > 1 ? ord($stream[1]) : -1;
+        $attemptInflate = static function (string $candidate): ?string {
+            $b0 = strlen($candidate) > 1 ? ord($candidate[0]) : -1;
+            $b1 = strlen($candidate) > 1 ? ord($candidate[1]) : -1;
 
-        // Gzip: magic bytes 0x1F 0x8B (RFC 1952). Try first when headers match.
-        if ($b0 === 0x1F && $b1 === 0x8B) {
-            $inflated = @gzdecode($stream);
+            // Gzip: magic bytes 0x1F 0x8B (RFC 1952). Try first when headers match.
+            if ($b0 === 0x1F && $b1 === 0x8B) {
+                $inflated = @gzdecode($candidate);
+                if (is_string($inflated)) {
+                    return $inflated;
+                }
+                // Fall through — misdetected gzip header; try other codecs below.
+            }
+
+            // zlib (RFC 1950): works for conforming PDF generators and some edge cases.
+            $inflated = @gzuncompress($candidate);
             if (is_string($inflated)) {
                 return $inflated;
             }
-            // Fall through — misdetected gzip header; try other codecs below.
-        }
 
-        // zlib (RFC 1950): works for conforming PDF generators and some edge cases.
-        $inflated = @gzuncompress($stream);
+            // Raw deflate (RFC 1951): no wrapper header; fallback for non-conforming generators.
+            $inflated = @gzinflate($candidate);
+            if (is_string($inflated)) {
+                return $inflated;
+            }
+
+            return null;
+        };
+
+        $inflated = $attemptInflate($stream);
         if (is_string($inflated)) {
             return $inflated;
         }
 
-        // Raw deflate (RFC 1951): no wrapper header; fallback for non-conforming generators.
-        $inflated = @gzinflate($stream);
-        if (is_string($inflated)) {
-            return $inflated;
+        // Non-conforming PDFs may leak one or more leading bytes before the compressed payload.
+        $trimmed = ltrim($stream, "\x00\x09\x0A\x0C\x0D\x20");
+        if ($trimmed !== $stream) {
+            $inflated = $attemptInflate($trimmed);
+            if (is_string($inflated)) {
+                return $inflated;
+            }
         }
 
         throw new PdfCoreParsingException('Failed to inflate FlateDecode stream.');

--- a/src/Infrastructure/PdfCore/Service/PdfObjectReader.php
+++ b/src/Infrastructure/PdfCore/Service/PdfObjectReader.php
@@ -13,7 +13,11 @@ final class PdfObjectReader
 {
     public function objectFromBuffer(string $buffer, int|string|null $expectedObjId, int $offset = 0, int &$offsetEnd = 0): PDFObject
     {
-        $headerMatchedAt = strpos($buffer, 'obj', $offset);
+        $bufferLength = strlen($buffer);
+        if ($offset < 0 || $offset >= $bufferLength) {
+            throw new PdfCoreParsingException('Invalid object definition: '.$expectedObjId);
+        }
+
         if (preg_match('/(\d+)\s+(\d+)\s+obj/ms', $buffer, $matches, PREG_OFFSET_CAPTURE, $offset) !== 1) {
             throw new PdfCoreParsingException('Invalid object definition: '.$expectedObjId);
         }

--- a/src/Infrastructure/PdfCore/Xref/Service/XRef14Parser.php
+++ b/src/Infrastructure/PdfCore/Xref/Service/XRef14Parser.php
@@ -41,25 +41,18 @@ final class XRef14Parser
         // before the first 'xref' keyword it finds, so the extra prefix is harmless.
         $expandedStart = max(0, $xrefPosition - 512);
         $xrefText = substr($buffer, $expandedStart, $trailerPosition - $expandedStart);
-        try {
-            $xrefTable = $this->parseEntries($xrefText, $xrefPosition);
-        } catch (PdfCoreParsingException $exception) {
-            // Regression from large corpus: startxref can point deep into a long table body,
-            // outside the 512-byte backward expansion. Retry from the last standalone xref
-            // keyword before the trailer boundary.
-            if (! str_starts_with($exception->getMessage(), 'Xref tag not found at position ')) {
-                throw $exception;
-            }
-
+        // Regression from large corpus: startxref can point deep into a long table body,
+        // outside the 512-byte backward expansion. Avoid exception-driven flow by checking
+        // upfront whether this window contains a standalone xref keyword.
+        if (! $this->containsStandaloneXrefKeyword($xrefText)) {
             $fallbackPosition = $this->findLastStandaloneXrefBefore($buffer, $trailerPosition);
-            if ($fallbackPosition === null || $fallbackPosition === $xrefPosition) {
-                throw $exception;
+            if ($fallbackPosition !== null && $fallbackPosition !== $xrefPosition) {
+                $xrefPosition = $fallbackPosition;
+                $xrefText = substr($buffer, $xrefPosition, $trailerPosition - $xrefPosition);
             }
-
-            $xrefPosition = $fallbackPosition;
-            $xrefText = substr($buffer, $xrefPosition, $trailerPosition - $xrefPosition);
-            $xrefTable = $this->parseEntries($xrefText, $xrefPosition);
         }
+
+        $xrefTable = $this->parseEntries($xrefText, $xrefPosition);
 
         $trailer = Trailer::new()
             ->withBuffer($buffer)
@@ -207,6 +200,24 @@ final class XRef14Parser
         $window = substr($buffer, 0, $beforeOffset);
 
         return $this->findLastXrefByScanning($window);
+    }
+
+    /**
+     * Detect whether the provided text contains a standalone `xref` keyword
+     * (followed by whitespace or end-of-string).
+     */
+    private function containsStandaloneXrefKeyword(string $text): bool
+    {
+        $searchOffset = 0;
+        while (($pos = strpos($text, 'xref', $searchOffset)) !== false) {
+            $after = $pos + 4;
+            if ($after >= strlen($text) || ctype_space($text[$after])) {
+                return true;
+            }
+            $searchOffset = $pos + 1;
+        }
+
+        return false;
     }
 
     /**

--- a/src/Infrastructure/PdfCore/Xref/Service/XRef14Parser.php
+++ b/src/Infrastructure/PdfCore/Xref/Service/XRef14Parser.php
@@ -41,18 +41,20 @@ final class XRef14Parser
         // before the first 'xref' keyword it finds, so the extra prefix is harmless.
         $expandedStart = max(0, $xrefPosition - 512);
         $xrefText = substr($buffer, $expandedStart, $trailerPosition - $expandedStart);
-        // Regression from large corpus: startxref can point deep into a long table body,
-        // outside the 512-byte backward expansion. Avoid exception-driven flow by checking
-        // upfront whether this window contains a standalone xref keyword.
-        if (! $this->containsStandaloneXrefKeyword($xrefText)) {
+        $xrefKeywordOffset = $this->findStandaloneXrefKeywordOffset($xrefText);
+        // Some malformed PDFs point startxref deep inside a long xref body, beyond the
+        // 512-byte backward expansion window. If this window has no standalone xref
+        // keyword, fallback to the last standalone xref found before the trailer.
+        if ($xrefKeywordOffset === null) {
             $fallbackPosition = $this->findLastStandaloneXrefBefore($buffer, $trailerPosition);
             if ($fallbackPosition !== null && $fallbackPosition !== $xrefPosition) {
                 $xrefPosition = $fallbackPosition;
                 $xrefText = substr($buffer, $xrefPosition, $trailerPosition - $xrefPosition);
+                $xrefKeywordOffset = $this->findStandaloneXrefKeywordOffset($xrefText);
             }
         }
 
-        $xrefTable = $this->parseEntries($xrefText, $xrefPosition);
+        $xrefTable = $this->parseEntries($xrefText, $xrefPosition, $xrefKeywordOffset);
 
         $trailer = Trailer::new()
             ->withBuffer($buffer)
@@ -74,24 +76,13 @@ final class XRef14Parser
      * @throws PdfCoreParsingException
      * @throws PdfCoreStructureException
      */
-    private function parseEntries(string $xrefText, int $xrefPosition): array
+    private function parseEntries(string $xrefText, int $xrefPosition, ?int $xrefKeywordOffset = null): array
     {
-        // Scan forward to find the 'xref' keyword — some generators have startxref pointing
-        // slightly before it (e.g. into trailing 'endobj'), or 'xref' may share a line with
-        // preceding tokens like 'endobj xref'.
-        $xrefKeywordOffset = false;
-        $searchOffset = 0;
-        while (($pos = strpos($xrefText, 'xref', $searchOffset)) !== false) {
-            // Verify 'xref' is followed by whitespace or end of string (not part of a longer word).
-            $after = $pos + 4;
-            if ($after >= strlen($xrefText) || ctype_space($xrefText[$after])) {
-                $xrefKeywordOffset = $pos;
-                break;
-            }
-            $searchOffset = $pos + 1;
+        if ($xrefKeywordOffset === null) {
+            $xrefKeywordOffset = $this->findStandaloneXrefKeywordOffset($xrefText);
         }
 
-        if ($xrefKeywordOffset === false) {
+        if ($xrefKeywordOffset === null) {
             throw new PdfCoreParsingException('Xref tag not found at position '.$xrefPosition);
         }
 
@@ -103,7 +94,6 @@ final class XRef14Parser
         $remainingObjectsInSection = 0;
         $xrefTable = [];
         $sawSectionHeader = false;
-        $parsedEntries = 0;
 
         // Initialize strtok; use a for-loop pattern to avoid strtok re-initialization issues.
         for ($line = strtok($xrefText, $lineSeparator); $line !== false; $line = strtok($lineSeparator)) {
@@ -127,7 +117,6 @@ final class XRef14Parser
             }
 
             $this->applyEntry($xrefTable, $currentObjectId, (int) $matches[1], (int) $matches[2], $matches[3]);
-            $parsedEntries++;
             $currentObjectId++;
             $remainingObjectsInSection--;
         }
@@ -203,21 +192,22 @@ final class XRef14Parser
     }
 
     /**
-     * Detect whether the provided text contains a standalone `xref` keyword
-     * (followed by whitespace or end-of-string).
+     * Find the first standalone `xref` keyword offset in the provided text.
+     *
+     * A standalone match is followed by whitespace or end-of-string.
      */
-    private function containsStandaloneXrefKeyword(string $text): bool
+    private function findStandaloneXrefKeywordOffset(string $text): ?int
     {
         $searchOffset = 0;
         while (($pos = strpos($text, 'xref', $searchOffset)) !== false) {
             $after = $pos + 4;
             if ($after >= strlen($text) || ctype_space($text[$after])) {
-                return true;
+                return $pos;
             }
             $searchOffset = $pos + 1;
         }
 
-        return false;
+        return null;
     }
 
     /**

--- a/src/Infrastructure/PdfCore/Xref/Service/XRef14Parser.php
+++ b/src/Infrastructure/PdfCore/Xref/Service/XRef14Parser.php
@@ -41,7 +41,25 @@ final class XRef14Parser
         // before the first 'xref' keyword it finds, so the extra prefix is harmless.
         $expandedStart = max(0, $xrefPosition - 512);
         $xrefText = substr($buffer, $expandedStart, $trailerPosition - $expandedStart);
-        $xrefTable = $this->parseEntries($xrefText, $xrefPosition);
+        try {
+            $xrefTable = $this->parseEntries($xrefText, $xrefPosition);
+        } catch (PdfCoreParsingException $exception) {
+            // Regression from large corpus: startxref can point deep into a long table body,
+            // outside the 512-byte backward expansion. Retry from the last standalone xref
+            // keyword before the trailer boundary.
+            if (! str_starts_with($exception->getMessage(), 'Xref tag not found at position ')) {
+                throw $exception;
+            }
+
+            $fallbackPosition = $this->findLastStandaloneXrefBefore($buffer, $trailerPosition);
+            if ($fallbackPosition === null || $fallbackPosition === $xrefPosition) {
+                throw $exception;
+            }
+
+            $xrefPosition = $fallbackPosition;
+            $xrefText = substr($buffer, $xrefPosition, $trailerPosition - $xrefPosition);
+            $xrefTable = $this->parseEntries($xrefText, $xrefPosition);
+        }
 
         $trailer = Trailer::new()
             ->withBuffer($buffer)
@@ -175,6 +193,20 @@ final class XRef14Parser
         }
 
         return null;
+    }
+
+    /**
+     * Return the last standalone `xref` keyword strictly before the given buffer offset.
+     */
+    private function findLastStandaloneXrefBefore(string $buffer, int $beforeOffset): ?int
+    {
+        if ($beforeOffset <= 0) {
+            return null;
+        }
+
+        $window = substr($buffer, 0, $beforeOffset);
+
+        return $this->findLastXrefByScanning($window);
     }
 
     /**

--- a/tests/Infrastructure/PdfCore/PDFObjectTest.php
+++ b/tests/Infrastructure/PdfCore/PDFObjectTest.php
@@ -67,4 +67,17 @@ final class PDFObjectTest extends TestCase
 
         $object->getStream(false);
     }
+
+    public function test_get_stream_decodes_flate_stream_with_leading_whitespace_prefix(): void
+    {
+        // Regression pattern from corpus: some malformed files include an extra whitespace
+        // byte before a valid Flate payload.
+        $payload = gzcompress('hello world');
+        self::assertIsString($payload);
+
+        $object = new PDFObject(1, ['Filter' => new PDFValueSimple('/FlateDecode')]);
+        $object->setStream("\n".$payload);
+
+        self::assertSame('hello world', $object->getStream(false));
+    }
 }

--- a/tests/Infrastructure/PdfCore/Service/PdfObjectReaderTest.php
+++ b/tests/Infrastructure/PdfCore/Service/PdfObjectReaderTest.php
@@ -34,4 +34,16 @@ final class PdfObjectReaderTest extends TestCase
         self::assertSame('XRef', $object['Type']->val());
         self::assertGreaterThan(0, $offsetEnd);
     }
+
+    public function test_object_from_buffer_throws_parsing_exception_when_offset_is_beyond_buffer(): void
+    {
+        $reader = new PdfObjectReader;
+        $buffer = "1 0 obj\n<< /Type /Catalog >>\nendobj\n";
+
+        $this->expectException(\SignerPHP\Infrastructure\PdfCore\Exception\PdfCoreParsingException::class);
+        $this->expectExceptionMessage('Invalid object definition: 1');
+
+        $offsetEnd = 0;
+        $reader->objectFromBuffer($buffer, 1, strlen($buffer) + 10, $offsetEnd);
+    }
 }

--- a/tests/Infrastructure/PdfCore/Xref/Service/XRef14ParserTest.php
+++ b/tests/Infrastructure/PdfCore/Xref/Service/XRef14ParserTest.php
@@ -90,6 +90,14 @@ final class XRef14ParserTest extends TestCase
                 0,
                 10,
             ],
+            'xref position beyond EOF recovered by newline-prefixed scan marker' => [
+                // Synthetic fixture from malformed corpus: xref is preceded by a newline and
+                // fallback must return the position after that newline (pos + 1).
+                "%PDF-1.4\nxref\n0 1\n0000000010 00000 n \ntrailer\n<< /Size 1 >>\nstartxref\n99999\n%%EOF\n",
+                99999,
+                0,
+                10,
+            ],
             'startxref offset points past xref keyword into table body (backward expansion)' => [
                 // Offset 5 is inside the xref table (after the "xref\n" keyword line at 0).
                 // The backward-expanded window (max 512 bytes) covers position 0 and finds it.
@@ -121,6 +129,21 @@ final class XRef14ParserTest extends TestCase
             ],
             'xref tag missing at provided position' => [
                 "no-tag-here\ntrailer\n<< /Size 1 >>\nstartxref\n0\n%%EOF\n",
+                0,
+                'Xref tag not found at position 0',
+            ],
+            'malformed xref rethrows without fallback retry' => [
+                // Synthetic fixture from problematic PDFs: xref section contains no valid header.
+                // parseEntries throws "Malformed xref...", and the catch block must rethrow
+                // immediately (non "Xref tag not found" message).
+                "xref\nnot-a-section-or-entry\ntrailer\n<< /Size 1 >>\nstartxref\n0\n%%EOF\n",
+                0,
+                'Malformed xref at position 0',
+            ],
+            'fallback retry with trailer at zero cannot scan before offset' => [
+                // Trailer at position 0 makes findLastStandaloneXrefBefore receive beforeOffset=0,
+                // which returns null and rethrows the original xref-tag-not-found error.
+                "trailer\n<< /Size 1 >>\nstartxref\n0\n%%EOF\n",
                 0,
                 'Xref tag not found at position 0',
             ],

--- a/tests/Infrastructure/PdfCore/Xref/Service/XRef14ParserTest.php
+++ b/tests/Infrastructure/PdfCore/Xref/Service/XRef14ParserTest.php
@@ -40,6 +40,18 @@ final class XRef14ParserTest extends TestCase
     /** @return array<string, array{string, int, int, int|null}> */
     public static function parseSuccessCases(): array
     {
+        $longXrefEntries = '';
+        for ($i = 0; $i < 80; $i++) {
+            $longXrefEntries .= sprintf("%010d 00000 n \n", 10 + $i);
+        }
+
+        $longXrefTable = "xref\n0 80\n".$longXrefEntries;
+        $longXrefBuffer = $longXrefTable."trailer\n<< /Size 80 >>\nstartxref\n0\n%%EOF\n";
+        $longXrefPositionInsideBody = strpos($longXrefBuffer, '0000000079 00000 n');
+        if ($longXrefPositionInsideBody === false) {
+            throw new \RuntimeException('Failed to build long xref regression fixture.');
+        }
+
         return [
             'prefixed chunk ending with xref keyword' => [
                 "endobj xref\n0 1\n0000000010 00000 n \ntrailer\n<< /Size 1 >>\nstartxref\n0\n%%EOF\n",
@@ -85,6 +97,14 @@ final class XRef14ParserTest extends TestCase
                 5,
                 0,
                 10,
+            ],
+            'startxref offset deep inside long xref table is recovered by fallback scan' => [
+                // Regression from corpus: startxref may point into a large xref body far from the
+                // keyword. The parser must still resolve the correct table header.
+                $longXrefBuffer,
+                $longXrefPositionInsideBody,
+                79,
+                89,
             ],
         ];
     }

--- a/tests/Unit/StructTest.php
+++ b/tests/Unit/StructTest.php
@@ -130,4 +130,22 @@ final class StructTest extends TestCase
         // xrefPosition is the offset of the 'xref' keyword, right after the %PDF-1.4\n header (9 bytes).
         self::assertSame(9, $structure->xrefPosition);
     }
+
+    public function test_parse_recovers_xref_at_buffer_start_with_crlf_keyword_when_startxref_is_missing_offset(): void
+    {
+        // Synthetic regression fixture from malformed PDFs: xref starts at byte 0 and uses
+        // CRLF after the keyword, while startxref exists but has no numeric offset.
+        // This forces fallback to the str_starts_with('xref\r\n') branch.
+        $pdf = "xref\r\n0 0\ntrailer\n<< /Size 1 >>\nstartxref\n%%EOF\n%PDF-1.4\n";
+        $document = new PdfDocument;
+        $document->setBufferFromString($pdf);
+
+        $structure = Struct::new()
+            ->withPdfDocument($document)
+            ->parse();
+
+        self::assertSame('PDF-1.4', $structure->version);
+        self::assertSame(0, $structure->xrefPosition);
+        self::assertSame([], $structure->xrefTable);
+    }
 }


### PR DESCRIPTION
This PR improves PDF core parsing robustness for malformed but recoverable files found in corpus regressions.

Changes:
- Added a safer FlateDecode inflate flow with retry on whitespace-prefixed payloads.
- Added defensive offset validation in object parsing to fail fast on invalid object positions.
- Added xref fallback recovery when startxref points deep inside long xref table bodies.
- Expanded regression test coverage for FlateDecode prefix handling, invalid object offsets, and deep xref-offset recovery.