### PR TITLE
fix(pdf-core): harden xref-stream fallback and filter decoding

### DIFF
--- a/src/Infrastructure/PdfCore/PDFObject.php
+++ b/src/Infrastructure/PdfCore/PDFObject.php
@@ -10,6 +10,7 @@ use SignerPHP\Infrastructure\PdfCore\Exception\PdfCoreStructureException;
 use SignerPHP\Infrastructure\PdfCore\PdfValue\PDFValue;
 use SignerPHP\Infrastructure\PdfCore\PdfValue\PDFValueObject;
 use SignerPHP\Infrastructure\PdfCore\PdfValue\PDFValueSimple;
+use SignerPHP\Infrastructure\PdfCore\Service\Ascii85Codec;
 use Stringable;
 
 class PDFObject implements ArrayAccess, Stringable
@@ -258,72 +259,6 @@ endstream
     }
 
     /**
-     * Decode an ASCII85 (Base85) stream into binary bytes.
-     *
-     * @throws PdfCoreParsingException
-     */
-    private static function ascii85DecodeStream(string $stream): string
-    {
-        $stream = trim($stream);
-        if (str_starts_with($stream, '<~') && str_ends_with($stream, '~>')) {
-            $stream = substr($stream, 2, -2);
-        }
-
-        $stream = preg_replace('/\s+/', '', $stream);
-        if (! is_string($stream)) {
-            throw new PdfCoreParsingException('Invalid ASCII85 stream data.');
-        }
-
-        $out = '';
-        $tuple = [];
-        $length = strlen($stream);
-
-        for ($i = 0; $i < $length; $i++) {
-            $ch = $stream[$i];
-
-            if ($ch === 'z') {
-                if ($tuple !== []) {
-                    throw new PdfCoreParsingException('Invalid ASCII85 stream data.');
-                }
-                $out .= "\0\0\0\0";
-
-                continue;
-            }
-
-            $ord = ord($ch);
-            if ($ord < 33 || $ord > 117) {
-                throw new PdfCoreParsingException('Invalid ASCII85 stream data.');
-            }
-
-            $tuple[] = $ord - 33;
-            if (count($tuple) === 5) {
-                $value = 0;
-                foreach ($tuple as $digit) {
-                    $value = ($value * 85) + $digit;
-                }
-                $out .= pack('N', $value);
-                $tuple = [];
-            }
-        }
-
-        if ($tuple !== []) {
-            $originalCount = count($tuple);
-            while (count($tuple) < 5) {
-                $tuple[] = 84;
-            }
-
-            $value = 0;
-            foreach ($tuple as $digit) {
-                $value = ($value * 85) + $digit;
-            }
-
-            $out .= substr(pack('N', $value), 0, $originalCount - 1);
-        }
-
-        return $out;
-    }
-
-    /**
      * @return list<string>
      */
     private static function normalizeFilters(mixed $filterField): array
@@ -373,7 +308,7 @@ endstream
             foreach ($filters as $filterName) {
                 switch ($filterName) {
                     case '/ASCII85Decode':
-                        $decoded = self::ascii85DecodeStream($decoded);
+                        $decoded = Ascii85Codec::decode($decoded);
 
                         break;
                     case '/FlateDecode':

--- a/src/Infrastructure/PdfCore/PDFObject.php
+++ b/src/Infrastructure/PdfCore/PDFObject.php
@@ -244,7 +244,120 @@ endstream
             }
         }
 
+        // Additional hardening: attempt to recover when arbitrary non-whitespace bytes
+        // precede a valid compressed payload (seen in malformed corpus fixtures).
+        $maxSkip = min(64, max(0, strlen($stream) - 2));
+        for ($skip = 1; $skip <= $maxSkip; $skip++) {
+            $inflated = $attemptInflate(substr($stream, $skip));
+            if (is_string($inflated)) {
+                return $inflated;
+            }
+        }
+
         throw new PdfCoreParsingException('Failed to inflate FlateDecode stream.');
+    }
+
+    /**
+     * Decode an ASCII85 (Base85) stream into binary bytes.
+     *
+     * @throws PdfCoreParsingException
+     */
+    private static function ascii85DecodeStream(string $stream): string
+    {
+        $stream = trim($stream);
+        if (str_starts_with($stream, '<~') && str_ends_with($stream, '~>')) {
+            $stream = substr($stream, 2, -2);
+        }
+
+        $stream = preg_replace('/\s+/', '', $stream);
+        if (! is_string($stream)) {
+            throw new PdfCoreParsingException('Invalid ASCII85 stream data.');
+        }
+
+        $out = '';
+        $tuple = [];
+        $length = strlen($stream);
+
+        for ($i = 0; $i < $length; $i++) {
+            $ch = $stream[$i];
+
+            if ($ch === 'z') {
+                if ($tuple !== []) {
+                    throw new PdfCoreParsingException('Invalid ASCII85 stream data.');
+                }
+                $out .= "\0\0\0\0";
+
+                continue;
+            }
+
+            $ord = ord($ch);
+            if ($ord < 33 || $ord > 117) {
+                throw new PdfCoreParsingException('Invalid ASCII85 stream data.');
+            }
+
+            $tuple[] = $ord - 33;
+            if (count($tuple) === 5) {
+                $value = 0;
+                foreach ($tuple as $digit) {
+                    $value = ($value * 85) + $digit;
+                }
+                $out .= pack('N', $value);
+                $tuple = [];
+            }
+        }
+
+        if ($tuple !== []) {
+            $originalCount = count($tuple);
+            while (count($tuple) < 5) {
+                $tuple[] = 84;
+            }
+
+            $value = 0;
+            foreach ($tuple as $digit) {
+                $value = ($value * 85) + $digit;
+            }
+
+            $out .= substr(pack('N', $value), 0, $originalCount - 1);
+        }
+
+        return $out;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function normalizeFilters(mixed $filterField): array
+    {
+        $filters = [];
+
+        if (is_object($filterField) && method_exists($filterField, 'val')) {
+            $raw = $filterField->val(true);
+            if (is_array($raw)) {
+                foreach ($raw as $candidate) {
+                    $name = (string) $candidate;
+                    if ($name !== '' && $name[0] !== '/') {
+                        $name = '/'.$name;
+                    }
+                    $filters[] = $name;
+                }
+
+                return $filters;
+            }
+
+            $name = (string) $filterField;
+            if ($name !== '' && $name[0] !== '/') {
+                $name = '/'.$name;
+            }
+
+            return [$name];
+        }
+
+        $name = (string) $filterField;
+        if ($name !== '' && $name[0] !== '/') {
+            $name = '/'.$name;
+        }
+
+        return [$name];
     }
 
     public function getStream($raw = true): string
@@ -254,35 +367,34 @@ endstream
         }
 
         if (isset($this->value['Filter'])) {
-            // Normalise: some generators write Filter as a one-element array [/FlateDecode]
-            // instead of the plain name /FlateDecode (ISO 32000 §7.3.8.2).
-            $filterField = $this->value['Filter'];
-            $filterValues = $filterField->val(true);
-            $filterName = is_array($filterValues) && count($filterValues) === 1
-                ? (string) array_values($filterValues)[0]
-                : (string) $filterField;
+            $decoded = (string) $this->stream;
+            $filters = self::normalizeFilters($this->value['Filter']);
 
-            // Re-add leading '/' if the filter value was stored without one.
-            if ($filterName !== '' && $filterName[0] !== '/') {
-                $filterName = '/'.$filterName;
+            foreach ($filters as $filterName) {
+                switch ($filterName) {
+                    case '/ASCII85Decode':
+                        $decoded = self::ascii85DecodeStream($decoded);
+
+                        break;
+                    case '/FlateDecode':
+                        $DecodeParams = $this->value['DecodeParms'] ?? [];
+                        $params = [
+                            'Columns' => $DecodeParams['Columns'] ?? new PDFValueSimple(0),
+                            'Predictor' => $DecodeParams['Predictor'] ?? new PDFValueSimple(1),
+                            'BitsPerComponent' => $DecodeParams['BitsPerComponent'] ?? new PDFValueSimple(8),
+                            'Colors' => $DecodeParams['Colors'] ?? new PDFValueSimple(1),
+                        ];
+
+                        $inflated = self::inflateFlateStream($decoded);
+                        $decoded = self::flateDecode($inflated, $params);
+
+                        break;
+                    default:
+                        throw new PdfCoreStructureException('Unknown compression method '.$filterName);
+                }
             }
 
-            switch ($filterName) {
-                case '/FlateDecode':
-                    $DecodeParams = $this->value['DecodeParms'] ?? [];
-                    $params = [
-                        'Columns' => $DecodeParams['Columns'] ?? new PDFValueSimple(0),
-                        'Predictor' => $DecodeParams['Predictor'] ?? new PDFValueSimple(1),
-                        'BitsPerComponent' => $DecodeParams['BitsPerComponent'] ?? new PDFValueSimple(8),
-                        'Colors' => $DecodeParams['Colors'] ?? new PDFValueSimple(1),
-                    ];
-
-                    $inflated = self::inflateFlateStream((string) $this->stream);
-
-                    return self::flateDecode($inflated, $params);
-                default:
-                    throw new PdfCoreStructureException('Unknown compression method '.$filterName);
-            }
+            return $decoded;
         }
 
         return (string) $this->stream;

--- a/src/Infrastructure/PdfCore/PDFObject.php
+++ b/src/Infrastructure/PdfCore/PDFObject.php
@@ -344,7 +344,7 @@ endstream
                 return $filters;
             }
 
-            $name = (string) $filterField;
+            $name = (string) $raw;
             if ($name !== '' && $name[0] !== '/') {
                 $name = '/'.$name;
             }

--- a/src/Infrastructure/PdfCore/Service/Ascii85Codec.php
+++ b/src/Infrastructure/PdfCore/Service/Ascii85Codec.php
@@ -116,18 +116,21 @@ final class Ascii85Codec
     private static function extractEncodedPayload(string $stream): string
     {
         $start = strpos($stream, '<~');
-        $end = strrpos($stream, '~>');
+        $end = strpos($stream, '~>');
 
-        if ($start !== false && $end !== false && $end > ($start + 1)) {
-            return substr($stream, $start + 2, $end - ($start + 2));
+        if ($start !== false) {
+            $startContent = $start + 2;
+            $endAfterStart = strpos($stream, '~>', $startContent);
+
+            if ($endAfterStart !== false && $endAfterStart >= $startContent) {
+                return substr($stream, $startContent, $endAfterStart - $startContent);
+            }
+
+            return substr($stream, $startContent);
         }
 
-        if (str_starts_with($stream, '<~') && str_ends_with($stream, '~>')) {
-            return substr($stream, 2, -2);
-        }
-
-        if (str_ends_with($stream, '~>')) {
-            return substr($stream, 0, -2);
+        if ($end !== false) {
+            return substr($stream, 0, $end);
         }
 
         return $stream;

--- a/src/Infrastructure/PdfCore/Service/Ascii85Codec.php
+++ b/src/Infrastructure/PdfCore/Service/Ascii85Codec.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SignerPHP\Infrastructure\PdfCore\Service;
+
+use SignerPHP\Infrastructure\PdfCore\Exception\PdfCoreParsingException;
+
+final class Ascii85Codec
+{
+    /**
+     * @throws PdfCoreParsingException
+     */
+    public static function decode(string $input): string
+    {
+        $stream = self::extractEncodedPayload(trim($input));
+        $stream = str_replace(["\x00", "\x09", "\x0A", "\x0C", "\x0D", "\x20"], '', $stream);
+
+        if ($stream === '') {
+            return '';
+        }
+
+        $output = '';
+        $value = 0;
+        $digits = 0;
+        $length = strlen($stream);
+
+        for ($i = 0; $i < $length; $i++) {
+            $ch = $stream[$i];
+
+            if ($ch === 'z') {
+                if ($digits !== 0) {
+                    throw new PdfCoreParsingException('Invalid ASCII85 stream data.');
+                }
+
+                $output .= "\0\0\0\0";
+
+                continue;
+            }
+
+            $ord = ord($ch);
+            if ($ord < 33 || $ord > 117) {
+                throw new PdfCoreParsingException('Invalid ASCII85 stream data.');
+            }
+
+            $value = ($value * 85) + ($ord - 33);
+            $digits++;
+
+            if ($digits === 5) {
+                $output .= pack('N', $value);
+                $value = 0;
+                $digits = 0;
+            }
+        }
+
+        if ($digits === 1) {
+            throw new PdfCoreParsingException('Invalid ASCII85 stream data.');
+        }
+
+        if ($digits > 1) {
+            for ($j = $digits; $j < 5; $j++) {
+                $value = ($value * 85) + 84;
+            }
+
+            $output .= substr(pack('N', $value), 0, $digits - 1);
+        }
+
+        return $output;
+    }
+
+    public static function encode(string $binary, bool $withDelimiters = true): string
+    {
+        $length = strlen($binary);
+        if ($length === 0) {
+            return $withDelimiters ? '<~~>' : '';
+        }
+
+        $parts = [];
+
+        for ($offset = 0; $offset < $length; $offset += 4) {
+            $remaining = $length - $offset;
+
+            if ($remaining >= 4) {
+                $chunk0 = ord($binary[$offset]);
+                $chunk1 = ord($binary[$offset + 1]);
+                $chunk2 = ord($binary[$offset + 2]);
+                $chunk3 = ord($binary[$offset + 3]);
+                $value = ($chunk0 << 24) | ($chunk1 << 16) | ($chunk2 << 8) | $chunk3;
+
+                if ($value === 0) {
+                    $parts[] = 'z';
+
+                    continue;
+                }
+
+                $parts[] = self::encodeChunk($value);
+
+                continue;
+            }
+
+            $p0 = ord($binary[$offset]);
+            $p1 = $remaining > 1 ? ord($binary[$offset + 1]) : 0;
+            $p2 = $remaining > 2 ? ord($binary[$offset + 2]) : 0;
+            $p3 = 0;
+            $value = ($p0 << 24) | ($p1 << 16) | ($p2 << 8) | $p3;
+
+            $encoded = self::encodeChunk($value);
+            $parts[] = substr($encoded, 0, $remaining + 1);
+        }
+
+        $encoded = implode('', $parts);
+
+        return $withDelimiters ? '<~'.$encoded.'~>' : $encoded;
+    }
+
+    private static function extractEncodedPayload(string $stream): string
+    {
+        $start = strpos($stream, '<~');
+        $end = strrpos($stream, '~>');
+
+        if ($start !== false && $end !== false && $end > ($start + 1)) {
+            return substr($stream, $start + 2, $end - ($start + 2));
+        }
+
+        if (str_starts_with($stream, '<~') && str_ends_with($stream, '~>')) {
+            return substr($stream, 2, -2);
+        }
+
+        if (str_ends_with($stream, '~>')) {
+            return substr($stream, 0, -2);
+        }
+
+        return $stream;
+    }
+
+    private static function encodeChunk(int $value): string
+    {
+        $bytes = "\0\0\0\0\0";
+
+        for ($i = 4; $i >= 0; $i--) {
+            $bytes[$i] = chr(($value % 85) + 33);
+            $value = intdiv($value, 85);
+        }
+
+        return $bytes;
+    }
+}

--- a/src/Infrastructure/PdfCore/Struct.php
+++ b/src/Infrastructure/PdfCore/Struct.php
@@ -127,7 +127,13 @@ class Struct
 
         // Last resort: no valid startxref offset found. Scan backward for the last
         // standalone 'xref' keyword so we can locate the xref table directly.
-        return $this->findLastStandaloneXref($buffer);
+        $xrefTablePosition = $this->findLastStandaloneXref($buffer);
+        if ($xrefTablePosition !== null) {
+            return $xrefTablePosition;
+        }
+
+        // Some malformed PDFs omit startxref entirely but still contain a valid xref stream.
+        return $this->findLastXrefStreamObjectPosition($buffer);
     }
 
     /**
@@ -152,5 +158,30 @@ class Struct
         }
 
         return null;
+    }
+
+    /**
+     * Find the byte offset of the last object header whose dictionary declares /Type /XRef.
+     * Returns null when no xref stream object can be identified.
+     */
+    private function findLastXrefStreamObjectPosition(string $buffer): ?int
+    {
+        $scanOffset = 0;
+        $lastObjectOffset = null;
+
+        while (preg_match('/\/Type\s*\/XRef\b/', $buffer, $typeMatch, PREG_OFFSET_CAPTURE, $scanOffset) === 1) {
+            $typeOffset = $typeMatch[0][1];
+            $windowStart = max(0, $typeOffset - 4096);
+            $window = substr($buffer, $windowStart, $typeOffset - $windowStart);
+
+            if (preg_match_all('/\d+\s+\d+\s+obj\b/', $window, $objectMatches, PREG_OFFSET_CAPTURE) > 0) {
+                $lastInWindowIndex = count($objectMatches[0]) - 1;
+                $lastObjectOffset = $windowStart + $objectMatches[0][$lastInWindowIndex][1];
+            }
+
+            $scanOffset = $typeOffset + 1;
+        }
+
+        return $lastObjectOffset;
     }
 }

--- a/src/Infrastructure/PdfCore/Struct.php
+++ b/src/Infrastructure/PdfCore/Struct.php
@@ -175,8 +175,8 @@ class Struct
             $window = substr($buffer, $windowStart, $typeOffset - $windowStart);
 
             if (preg_match_all('/\d+\s+\d+\s+obj\b/', $window, $objectMatches, PREG_OFFSET_CAPTURE) > 0) {
-                $lastInWindowIndex = count($objectMatches[0]) - 1;
-                $lastObjectOffset = $windowStart + $objectMatches[0][$lastInWindowIndex][1];
+                $lastObject = end($objectMatches[0]);
+                $lastObjectOffset = $windowStart + $lastObject[1];
             }
 
             $scanOffset = $typeOffset + 1;

--- a/tests/Infrastructure/PdfCore/PDFObjectTest.php
+++ b/tests/Infrastructure/PdfCore/PDFObjectTest.php
@@ -7,6 +7,7 @@ namespace SignerPHP\Tests\Infrastructure\PdfCore;
 use PHPUnit\Framework\TestCase;
 use SignerPHP\Infrastructure\PdfCore\PDFObject;
 use SignerPHP\Infrastructure\PdfCore\PdfValue\PDFValueList;
+use SignerPHP\Infrastructure\PdfCore\PdfValue\PDFValueObject;
 use SignerPHP\Infrastructure\PdfCore\PdfValue\PDFValueSimple;
 
 final class PDFObjectTest extends TestCase
@@ -106,6 +107,67 @@ final class PDFObjectTest extends TestCase
             ]),
         ]);
         $object->setStream(self::ascii85Encode($flatePayload));
+
+        self::assertSame('hello world', $object->getStream(false));
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function invalidAscii85Payloads(): array
+    {
+        return [
+            'z marker after a partial tuple' => ['!z'],
+            'out of range ascii85 byte' => ['~'],
+        ];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('invalidAscii85Payloads')]
+    public function test_get_stream_throws_for_invalid_ascii85_payload(string $payload): void
+    {
+        $object = new PDFObject(1, ['Filter' => new PDFValueSimple('/ASCII85Decode')]);
+        $object->setStream($payload);
+
+        $this->expectException(\SignerPHP\Infrastructure\PdfCore\Exception\PdfCoreParsingException::class);
+        $this->expectExceptionMessage('Invalid ASCII85 stream data.');
+
+        $object->getStream(false);
+    }
+
+    public function test_get_stream_decodes_flate_filter_when_filter_name_is_unprefixed_scalar_value(): void
+    {
+        $object = new PDFObject(1, ['Filter' => new PDFValueSimple('FlateDecode')]);
+
+        $payload = gzcompress('hello world');
+        self::assertIsString($payload);
+        $object->setStream($payload);
+
+        self::assertSame('hello world', $object->getStream(false));
+    }
+
+    public function test_get_stream_decodes_flate_filter_when_filter_name_is_returned_as_plain_string(): void
+    {
+        $filterValue = new class(['Filter' => 'FlateDecode']) extends PDFValueObject {
+            public function offsetExists($offset): bool
+            {
+                return $offset === 'Filter';
+            }
+
+            public function offsetGet($offset): mixed
+            {
+                if ($offset === 'Filter') {
+                    return 'FlateDecode';
+                }
+
+                return null;
+            }
+        };
+
+        $object = new PDFObject(1, $filterValue);
+
+        $payload = gzcompress('hello world');
+        self::assertIsString($payload);
+        $object->setStream($payload);
 
         self::assertSame('hello world', $object->getStream(false));
     }

--- a/tests/Infrastructure/PdfCore/PDFObjectTest.php
+++ b/tests/Infrastructure/PdfCore/PDFObjectTest.php
@@ -80,4 +80,64 @@ final class PDFObjectTest extends TestCase
 
         self::assertSame('hello world', $object->getStream(false));
     }
+
+    public function test_get_stream_decodes_flate_stream_with_non_whitespace_prefix(): void
+    {
+        // Regression pattern from corpus: some inputs prepend non-whitespace bytes
+        // before a valid compressed Flate payload.
+        $payload = gzcompress('hello world');
+        self::assertIsString($payload);
+
+        $object = new PDFObject(1, ['Filter' => new PDFValueSimple('/FlateDecode')]);
+        $object->setStream('XX'.$payload);
+
+        self::assertSame('hello world', $object->getStream(false));
+    }
+
+    public function test_get_stream_decodes_ascii85_then_flate_filter_chain(): void
+    {
+        $flatePayload = gzcompress('hello world');
+        self::assertIsString($flatePayload);
+
+        $object = new PDFObject(1, [
+            'Filter' => new PDFValueList([
+                new PDFValueSimple('ASCII85Decode'),
+                new PDFValueSimple('FlateDecode'),
+            ]),
+        ]);
+        $object->setStream(self::ascii85Encode($flatePayload));
+
+        self::assertSame('hello world', $object->getStream(false));
+    }
+
+    private static function ascii85Encode(string $data): string
+    {
+        $out = '';
+        $length = strlen($data);
+
+        for ($i = 0; $i < $length; $i += 4) {
+            $chunk = substr($data, $i, 4);
+            $chunkLength = strlen($chunk);
+            if ($chunkLength < 4) {
+                $chunk = str_pad($chunk, 4, "\0", STR_PAD_RIGHT);
+            }
+
+            $value = unpack('N', $chunk)[1];
+            if ($chunkLength === 4 && $value === 0) {
+                $out .= 'z';
+
+                continue;
+            }
+
+            $encoded = '';
+            for ($j = 0; $j < 5; $j++) {
+                $encoded = chr(($value % 85) + 33).$encoded;
+                $value = intdiv($value, 85);
+            }
+
+            $out .= $chunkLength < 4 ? substr($encoded, 0, $chunkLength + 1) : $encoded;
+        }
+
+        return '<~'.$out.'~>';
+    }
 }

--- a/tests/Infrastructure/PdfCore/PDFObjectTest.php
+++ b/tests/Infrastructure/PdfCore/PDFObjectTest.php
@@ -147,7 +147,8 @@ final class PDFObjectTest extends TestCase
 
     public function test_get_stream_decodes_flate_filter_when_filter_name_is_returned_as_plain_string(): void
     {
-        $filterValue = new class(['Filter' => 'FlateDecode']) extends PDFValueObject {
+        $filterValue = new class(['Filter' => 'FlateDecode']) extends PDFValueObject
+        {
             public function offsetExists($offset): bool
             {
                 return $offset === 'Filter';

--- a/tests/Infrastructure/PdfCore/PDFObjectTest.php
+++ b/tests/Infrastructure/PdfCore/PDFObjectTest.php
@@ -10,6 +10,7 @@ use SignerPHP\Infrastructure\PdfCore\PDFObject;
 use SignerPHP\Infrastructure\PdfCore\PdfValue\PDFValueList;
 use SignerPHP\Infrastructure\PdfCore\PdfValue\PDFValueObject;
 use SignerPHP\Infrastructure\PdfCore\PdfValue\PDFValueSimple;
+use SignerPHP\Infrastructure\PdfCore\Service\Ascii85Codec;
 
 final class PDFObjectTest extends TestCase
 {
@@ -107,7 +108,7 @@ final class PDFObjectTest extends TestCase
                 new PDFValueSimple('FlateDecode'),
             ]),
         ]);
-        $object->setStream(self::ascii85Encode($flatePayload));
+        $object->setStream(Ascii85Codec::encode($flatePayload));
 
         self::assertSame('hello world', $object->getStream(false));
     }
@@ -172,36 +173,5 @@ final class PDFObjectTest extends TestCase
         $object->setStream($payload);
 
         self::assertSame('hello world', $object->getStream(false));
-    }
-
-    private static function ascii85Encode(string $data): string
-    {
-        $out = '';
-        $length = strlen($data);
-
-        for ($i = 0; $i < $length; $i += 4) {
-            $chunk = substr($data, $i, 4);
-            $chunkLength = strlen($chunk);
-            if ($chunkLength < 4) {
-                $chunk = str_pad($chunk, 4, "\0", STR_PAD_RIGHT);
-            }
-
-            $value = unpack('N', $chunk)[1];
-            if ($chunkLength === 4 && $value === 0) {
-                $out .= 'z';
-
-                continue;
-            }
-
-            $encoded = '';
-            for ($j = 0; $j < 5; $j++) {
-                $encoded = chr(($value % 85) + 33).$encoded;
-                $value = intdiv($value, 85);
-            }
-
-            $out .= $chunkLength < 4 ? substr($encoded, 0, $chunkLength + 1) : $encoded;
-        }
-
-        return '<~'.$out.'~>';
     }
 }

--- a/tests/Infrastructure/PdfCore/PDFObjectTest.php
+++ b/tests/Infrastructure/PdfCore/PDFObjectTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SignerPHP\Tests\Infrastructure\PdfCore;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use SignerPHP\Infrastructure\PdfCore\PDFObject;
 use SignerPHP\Infrastructure\PdfCore\PdfValue\PDFValueList;
@@ -49,7 +50,7 @@ final class PDFObjectTest extends TestCase
     /**
      * @param  callable(): string  $buildStream
      */
-    #[\PHPUnit\Framework\Attributes\DataProvider('flateStreamEncodings')]
+    #[DataProvider('flateStreamEncodings')]
     public function test_get_stream_decodes_all_flate_encoding_variants(callable $buildStream, string $expected): void
     {
         $object = new PDFObject(1, ['Filter' => new PDFValueSimple('/FlateDecode')]);
@@ -122,7 +123,7 @@ final class PDFObjectTest extends TestCase
         ];
     }
 
-    #[\PHPUnit\Framework\Attributes\DataProvider('invalidAscii85Payloads')]
+    #[DataProvider('invalidAscii85Payloads')]
     public function test_get_stream_throws_for_invalid_ascii85_payload(string $payload): void
     {
         $object = new PDFObject(1, ['Filter' => new PDFValueSimple('/ASCII85Decode')]);

--- a/tests/Infrastructure/PdfCore/Service/Ascii85CodecTest.php
+++ b/tests/Infrastructure/PdfCore/Service/Ascii85CodecTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SignerPHP\Tests\Infrastructure\PdfCore\Service;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use SignerPHP\Infrastructure\PdfCore\Exception\PdfCoreParsingException;
+use SignerPHP\Infrastructure\PdfCore\Service\Ascii85Codec;
+
+final class Ascii85CodecTest extends TestCase
+{
+    /** @return array<string, array{string}> */
+    public static function roundTripPayloads(): array
+    {
+        return [
+            'empty payload' => [''],
+            'simple text' => ['hello world'],
+            'binary bytes with nulls' => ["\x00\x01\x02\x03\x00\xFF"],
+            'longer deterministic payload' => [str_repeat('pdf-core-', 32)],
+        ];
+    }
+
+    #[DataProvider('roundTripPayloads')]
+    public function test_encode_decode_round_trip(string $payload): void
+    {
+        $encoded = Ascii85Codec::encode($payload);
+
+        self::assertSame($payload, Ascii85Codec::decode($encoded));
+    }
+
+    public function test_decode_accepts_payload_with_embedded_delimiters_and_whitespace(): void
+    {
+        $encoded = Ascii85Codec::encode('hello world');
+        $decorated = "prefix  \n{$encoded}\n  suffix";
+
+        self::assertSame('hello world', Ascii85Codec::decode($decorated));
+    }
+
+    public function test_decode_accepts_terminator_only_variant_used_in_pdf_streams(): void
+    {
+        $encodedWithoutStart = substr(Ascii85Codec::encode('abc'), 2);
+
+        self::assertSame('abc', Ascii85Codec::decode($encodedWithoutStart));
+    }
+
+    public function test_encode_uses_z_shortcut_for_four_null_bytes(): void
+    {
+        self::assertSame('<~z~>', Ascii85Codec::encode("\0\0\0\0"));
+    }
+
+    /** @return array<string, array{string}> */
+    public static function invalidPayloads(): array
+    {
+        return [
+            'z marker after partial tuple' => ['!z'],
+            'invalid ascii85 character' => ['~'],
+            'single trailing base85 digit' => ['!'],
+        ];
+    }
+
+    #[DataProvider('invalidPayloads')]
+    public function test_decode_throws_for_invalid_payload(string $invalid): void
+    {
+        $this->expectException(PdfCoreParsingException::class);
+        $this->expectExceptionMessage('Invalid ASCII85 stream data.');
+
+        Ascii85Codec::decode($invalid);
+    }
+}

--- a/tests/Infrastructure/PdfCore/Service/Ascii85CodecTest.php
+++ b/tests/Infrastructure/PdfCore/Service/Ascii85CodecTest.php
@@ -120,6 +120,23 @@ final class Ascii85CodecTest extends TestCase
         self::assertSame('abc', Ascii85Codec::decode($decorated));
     }
 
+    /** @return array<string, array{string, string}> */
+    public static function acceptedNonCanonicalPayloads(): array
+    {
+        return [
+            'terminator only with trailing noise' => ['@:E^~>suffix_after_terminator', 'abc'],
+            'start delimiter without terminator' => ['<~@:E^', 'abc'],
+            'prefixed and suffixed wrappers' => ['garbage<~@:E^~>trailer', 'abc'],
+            'single encoded block between noisy text' => ['header<~z~>footer', "\0\0\0\0"],
+        ];
+    }
+
+    #[DataProvider('acceptedNonCanonicalPayloads')]
+    public function test_decode_accepts_non_canonical_but_recoverable_stream_shapes(string $encoded, string $expected): void
+    {
+        self::assertSame($expected, Ascii85Codec::decode($encoded));
+    }
+
     public function test_encode_uses_z_shortcut_for_four_null_bytes(): void
     {
         self::assertSame('<~z~>', Ascii85Codec::encode("\0\0\0\0"));
@@ -152,6 +169,8 @@ final class Ascii85CodecTest extends TestCase
             'btoa y shorthand is unsupported' => ['y'],
             'out of range byte after valid tuple' => ['!!!!!{'],
             'del char out of range' => ["!!!!!\x7F"],
+            'single digit in delimiters' => ['<~@~>'],
+            'single digit with terminator only form' => ['@~>'],
         ];
     }
 

--- a/tests/Infrastructure/PdfCore/Service/Ascii85CodecTest.php
+++ b/tests/Infrastructure/PdfCore/Service/Ascii85CodecTest.php
@@ -11,6 +11,34 @@ use SignerPHP\Infrastructure\PdfCore\Service\Ascii85Codec;
 
 final class Ascii85CodecTest extends TestCase
 {
+    /** @return array<string, array{string, string}> */
+    public static function canonicalVectors(): array
+    {
+        return [
+            'empty payload' => ['', '<~~>'],
+            'single byte' => ['a', '<~@/~>'],
+            'two bytes' => ['ab', '<~@:B~>'],
+            'three bytes' => ['abc', '<~@:E^~>'],
+            'four bytes' => ['abcd', '<~@:E_W~>'],
+            'man chunk' => ['Man ', '<~9jqo^~>'],
+            'hello world' => ['hello world', '<~BOu!rD]j7BEbo7~>'],
+            'hello world punctuation' => ['Hello, world!', '<~87cURD_*#TDfTZ)+T~>'],
+            'all zero chunk shortcut' => ["\0\0\0\0", '<~z~>'],
+        ];
+    }
+
+    #[DataProvider('canonicalVectors')]
+    public function test_encode_matches_canonical_vectors(string $payload, string $expected): void
+    {
+        self::assertSame($expected, Ascii85Codec::encode($payload));
+    }
+
+    #[DataProvider('canonicalVectors')]
+    public function test_decode_matches_canonical_vectors(string $expectedPayload, string $encoded): void
+    {
+        self::assertSame($expectedPayload, Ascii85Codec::decode($encoded));
+    }
+
     /** @return array<string, array{string}> */
     public static function roundTripPayloads(): array
     {
@@ -30,10 +58,49 @@ final class Ascii85CodecTest extends TestCase
         self::assertSame($payload, Ascii85Codec::decode($encoded));
     }
 
+    public function test_encode_without_delimiters_round_trips(): void
+    {
+        $payload = "\x00\x01\x02\x03binary payload";
+        $encoded = Ascii85Codec::encode($payload, false);
+
+        self::assertSame($payload, Ascii85Codec::decode($encoded));
+    }
+
+    /** @return array<string, array{int}> */
+    public static function chunkBoundaryLengths(): array
+    {
+        return [
+            'length 1' => [1],
+            'length 2' => [2],
+            'length 3' => [3],
+            'length 4' => [4],
+            'length 5' => [5],
+            'length 7' => [7],
+            'length 8' => [8],
+        ];
+    }
+
+    #[DataProvider('chunkBoundaryLengths')]
+    public function test_encode_decode_handles_chunk_boundaries(int $length): void
+    {
+        $payload = substr("\x00\x01\x02\x03\x04\x05\x06\x07", 0, $length);
+        $encoded = Ascii85Codec::encode($payload);
+
+        self::assertSame($payload, Ascii85Codec::decode($encoded));
+    }
+
     public function test_decode_accepts_payload_with_embedded_delimiters_and_whitespace(): void
     {
         $encoded = Ascii85Codec::encode('hello world');
         $decorated = "prefix  \n{$encoded}\n  suffix";
+
+        self::assertSame('hello world', Ascii85Codec::decode($decorated));
+    }
+
+    public function test_decode_accepts_payload_with_pdf_whitespace_set(): void
+    {
+        $encoded = Ascii85Codec::encode('hello world');
+        $decorated = "\x00\t\n\f\r ".substr($encoded, 0, 6)."\n\t".substr($encoded, 6)."\x0C";
 
         self::assertSame('hello world', Ascii85Codec::decode($decorated));
     }
@@ -45,9 +112,34 @@ final class Ascii85CodecTest extends TestCase
         self::assertSame('abc', Ascii85Codec::decode($encodedWithoutStart));
     }
 
+    public function test_decode_prefers_content_between_delimiters_when_wrapped_in_noise(): void
+    {
+        $encoded = Ascii85Codec::encode('abc');
+        $decorated = 'noise_before'.$encoded.'noise_after';
+
+        self::assertSame('abc', Ascii85Codec::decode($decorated));
+    }
+
     public function test_encode_uses_z_shortcut_for_four_null_bytes(): void
     {
         self::assertSame('<~z~>', Ascii85Codec::encode("\0\0\0\0"));
+    }
+
+    public function test_encode_expands_non_full_zero_chunk_without_z_shortcut(): void
+    {
+        self::assertSame('<~!!!!~>', Ascii85Codec::encode("\0\0\0"));
+    }
+
+    public function test_round_trip_deterministic_binary_stress_sample(): void
+    {
+        $bytes = '';
+        for ($i = 0; $i < 8192; $i++) {
+            $bytes .= chr((($i * 17) + 53) & 0xFF);
+        }
+
+        $encoded = Ascii85Codec::encode($bytes);
+
+        self::assertSame($bytes, Ascii85Codec::decode($encoded));
     }
 
     /** @return array<string, array{string}> */
@@ -57,6 +149,9 @@ final class Ascii85CodecTest extends TestCase
             'z marker after partial tuple' => ['!z'],
             'invalid ascii85 character' => ['~'],
             'single trailing base85 digit' => ['!'],
+            'btoa y shorthand is unsupported' => ['y'],
+            'out of range byte after valid tuple' => ['!!!!!{'],
+            'del char out of range' => ["!!!!!\x7F"],
         ];
     }
 

--- a/tests/Unit/StructTest.php
+++ b/tests/Unit/StructTest.php
@@ -148,4 +148,33 @@ final class StructTest extends TestCase
         self::assertSame(0, $structure->xrefPosition);
         self::assertSame([], $structure->xrefTable);
     }
+
+    public function test_parse_recovers_xref_stream_position_when_startxref_is_missing(): void
+    {
+        // Regression fixture: malformed file has no startxref section, but does contain
+        // a valid xref stream object that should be discovered by fallback scanning.
+        $xrefStreamData = chr(1).pack('n', 0).chr(0)
+            .chr(1).pack('n', 9).chr(0);
+        $xrefLength = strlen($xrefStreamData);
+
+        $xrefObject = "5 0 obj\n<< /Type /XRef /W [1 2 1] /Size 2 /Index [0 2] /Length {$xrefLength} >>\nstream\n"
+            .$xrefStreamData
+            ."\nendstream\nendobj\n";
+        $pdf = "%PDF-1.5\n1 0 obj\n<< /Type /Catalog >>\nendobj\n".$xrefObject."%%EOF\n";
+        $xrefOffset = strpos($pdf, '5 0 obj');
+        if ($xrefOffset === false) {
+            self::fail('Could not build xref stream fixture.');
+        }
+
+        $document = new PdfDocument;
+        $document->setBufferFromString($pdf);
+
+        $structure = Struct::new()
+            ->withPdfDocument($document)
+            ->parse();
+
+        self::assertSame('PDF-1.5', $structure->version);
+        self::assertSame($xrefOffset, $structure->xrefPosition);
+        self::assertSame(9, $structure->xrefTable[1]);
+    }
 }


### PR DESCRIPTION
This PR hardens PDF core parsing for two additional failure patterns found in corpus regressions: xref stream fallback and filter chain decoding.

Changes:
- Added xref stream fallback in `Struct::resolveXrefPosition()` to locate the last `/Type /XRef` object when no valid `startxref` or standalone `xref` table is found.
- Added filter chain support in `PDFObject::getStream()` to decode multi-filter sequences, including `ASCII85Decode` followed by `FlateDecode`.
- Added extra non-whitespace prefix recovery in `PDFObject::inflateFlateStream()` for payloads preceded by arbitrary bytes.
- Expanded regression test coverage for xref stream without `startxref`, non-whitespace Flate prefix, and `ASCII85Decode` + `FlateDecode` filter chains.