### PR TITLE
fix(pdf-core): harden malformed xref/object-stream recovery with per-file signed commits

### DIFF
--- a/src/Infrastructure/PdfCore/PDFObject.php
+++ b/src/Infrastructure/PdfCore/PDFObject.php
@@ -203,59 +203,125 @@ endstream
      */
     private static function inflateFlateStream(string $stream): string
     {
-        $attemptInflate = static function (string $candidate): ?string {
-            $b0 = strlen($candidate) > 1 ? ord($candidate[0]) : -1;
-            $b1 = strlen($candidate) > 1 ? ord($candidate[1]) : -1;
-
-            // Gzip: magic bytes 0x1F 0x8B (RFC 1952). Try first when headers match.
-            if ($b0 === 0x1F && $b1 === 0x8B) {
-                $inflated = @gzdecode($candidate);
-                if (is_string($inflated)) {
-                    return $inflated;
-                }
-                // Fall through — misdetected gzip header; try other codecs below.
-            }
-
-            // zlib (RFC 1950): works for conforming PDF generators and some edge cases.
-            $inflated = @gzuncompress($candidate);
-            if (is_string($inflated)) {
-                return $inflated;
-            }
-
-            // Raw deflate (RFC 1951): no wrapper header; fallback for non-conforming generators.
-            $inflated = @gzinflate($candidate);
-            if (is_string($inflated)) {
-                return $inflated;
-            }
-
-            return null;
-        };
-
-        $inflated = $attemptInflate($stream);
+        $inflated = self::attemptInflateCandidate($stream);
         if (is_string($inflated)) {
             return $inflated;
         }
 
-        // Non-conforming PDFs may leak one or more leading bytes before the compressed payload.
-        $trimmed = ltrim($stream, "\x00\x09\x0A\x0C\x0D\x20");
-        if ($trimmed !== $stream) {
-            $inflated = $attemptInflate($trimmed);
-            if (is_string($inflated)) {
-                return $inflated;
-            }
+        $inflated = self::tryInflateAfterWhitespaceTrim($stream);
+        if (is_string($inflated)) {
+            return $inflated;
         }
 
-        // Additional hardening: attempt to recover when arbitrary non-whitespace bytes
-        // precede a valid compressed payload (seen in malformed corpus fixtures).
-        $maxSkip = min(64, max(0, strlen($stream) - 2));
-        for ($skip = 1; $skip <= $maxSkip; $skip++) {
-            $inflated = $attemptInflate(substr($stream, $skip));
-            if (is_string($inflated)) {
-                return $inflated;
-            }
+        $inflated = self::tryInflateWithBoundedPrefixSkip($stream);
+        if (is_string($inflated)) {
+            return $inflated;
+        }
+
+        $inflated = self::tryInflateByHeaderScan($stream);
+        if (is_string($inflated)) {
+            return $inflated;
         }
 
         throw new PdfCoreParsingException('Failed to inflate FlateDecode stream.');
+    }
+
+    private static function attemptInflateCandidate(string $candidate): ?string
+    {
+        $b0 = strlen($candidate) > 1 ? ord($candidate[0]) : -1;
+        $b1 = strlen($candidate) > 1 ? ord($candidate[1]) : -1;
+
+        // Gzip: magic bytes 0x1F 0x8B (RFC 1952). Try first when headers match.
+        if (self::isGzipHeader($b0, $b1)) {
+            $inflated = @gzdecode($candidate);
+            if (is_string($inflated)) {
+                return $inflated;
+            }
+            // Fall through — misdetected gzip header; try other codecs below.
+        }
+
+        // zlib (RFC 1950): works for conforming PDF generators and some edge cases.
+        $inflated = @gzuncompress($candidate);
+        if (is_string($inflated)) {
+            return $inflated;
+        }
+
+        // Raw deflate (RFC 1951): no wrapper header; fallback for non-conforming generators.
+        $inflated = @gzinflate($candidate);
+        if (is_string($inflated)) {
+            return $inflated;
+        }
+
+        return null;
+    }
+
+    private static function tryInflateAfterWhitespaceTrim(string $stream): ?string
+    {
+        // Non-conforming PDFs may leak one or more leading bytes before the compressed payload.
+        $trimmed = ltrim($stream, "\x00\x09\x0A\x0C\x0D\x20");
+        if ($trimmed === $stream) {
+            return null;
+        }
+
+        return self::attemptInflateCandidate($trimmed);
+    }
+
+    private static function tryInflateWithBoundedPrefixSkip(string $stream): ?string
+    {
+        // Additional hardening: attempt to recover when arbitrary non-whitespace bytes
+        // precede a valid compressed payload (seen in malformed corpus fixtures).
+        // Keep a bounded search window to avoid pathological CPU cost on huge streams.
+        $maxSkip = min(2048, max(0, strlen($stream) - 2));
+        for ($skip = 1; $skip <= $maxSkip; $skip++) {
+            $inflated = self::attemptInflateCandidate(substr($stream, $skip));
+            if (is_string($inflated)) {
+                return $inflated;
+            }
+        }
+
+        return null;
+    }
+
+    private static function tryInflateByHeaderScan(string $stream): ?string
+    {
+        // If the compressed payload starts far from the stream start, blind linear probing
+        // is too expensive. Scan a bounded prefix for plausible zlib/gzip headers first.
+        $streamLength = strlen($stream);
+        $maxHeaderScan = min(65536, max(0, $streamLength - 2));
+        $attempts = 0;
+
+        for ($offset = 1; $offset <= $maxHeaderScan; $offset++) {
+            $b0 = ord($stream[$offset]);
+            $b1 = ord($stream[$offset + 1]);
+
+            if (! self::isGzipHeader($b0, $b1) && ! self::isPlausibleZlibHeader($b0, $b1)) {
+                continue;
+            }
+
+            $attempts++;
+            $inflated = self::attemptInflateCandidate(substr($stream, $offset));
+            if (is_string($inflated)) {
+                return $inflated;
+            }
+
+            // Keep this fallback bounded to avoid excessive decompression attempts.
+            if ($attempts >= 64) {
+                break;
+            }
+        }
+
+        return null;
+    }
+
+    private static function isGzipHeader(int $b0, int $b1): bool
+    {
+        return $b0 === 0x1F && $b1 === 0x8B;
+    }
+
+    private static function isPlausibleZlibHeader(int $b0, int $b1): bool
+    {
+        return ($b0 & 0x0F) === 0x08
+            && ((($b0 << 8) + $b1) % 31) === 0;
     }
 
     /**

--- a/src/Infrastructure/PdfCore/Service/ObjectStreamResolver.php
+++ b/src/Infrastructure/PdfCore/Service/ObjectStreamResolver.php
@@ -40,23 +40,50 @@ final class ObjectStreamResolver
             throw new PdfCoreStructureException('Invalid first object position in object stream '.$objstmOid);
         }
 
+        $nValue = $n->asIntOrNull();
+        if ($nValue === null || $nValue < 0) {
+            throw new PdfCoreStructureException('Invalid object count in object stream '.$objstmOid);
+        }
+
         $stream = $objstm->getStream(false);
         $index = substr((string) $stream, 0, $firstValue);
-        // Split on any whitespace (tabs, multiple spaces, newlines) to tolerate
-        // non-conforming generators that don't use single spaces (ISO 32000 §7.5.7).
-        $index = preg_split('/\s+/', trim($index), -1, PREG_SPLIT_NO_EMPTY);
+        preg_match_all('/-?\d+/', $index, $indexMatches);
+        $index = $indexMatches[0] ?? [];
         $stream = substr((string) $stream, $firstValue);
 
-        if (count($index) % 2 !== 0) {
+        $expectedEntries = $nValue * 2;
+        if ($expectedEntries > 0 && count($index) >= $expectedEntries) {
+            $index = array_slice($index, 0, $expectedEntries);
+        }
+
+        if (count($index) < 2 || count($index) % 2 !== 0) {
             throw new PdfCoreParsingException('Invalid index for object stream '.$objstmOid);
         }
 
-        $objpos *= 2;
-        if ($objpos < 0 || ($objpos + 1) >= count($index)) {
+        $pairIndex = $objpos * 2;
+        $offset = null;
+
+        if ($pairIndex >= 0 && ($pairIndex + 1) < count($index)) {
+            $indexedOid = (int) $index[$pairIndex];
+            if ($indexedOid === $oid) {
+                $offset = (int) $index[$pairIndex + 1];
+            }
+        }
+
+        if ($offset === null) {
+            $indexCount = count($index);
+            for ($i = 0; $i + 1 < $indexCount; $i += 2) {
+                if ((int) $index[$i] === $oid) {
+                    $offset = (int) $index[$i + 1];
+                    break;
+                }
+            }
+        }
+
+        if ($offset === null) {
             throw new PdfCoreStructureException(sprintf('Object %s not found in object stream %s.', $oid, $objstmOid));
         }
 
-        $offset = (int) $index[$objpos + 1];
         $offsets = [];
         $counter = count($index);
         for ($i = 1; $i < $counter; $i += 2) {

--- a/src/Infrastructure/PdfCore/Struct.php
+++ b/src/Infrastructure/PdfCore/Struct.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SignerPHP\Infrastructure\PdfCore;
 
 use Exception;
+use SignerPHP\Infrastructure\PdfCore\PdfValue\PDFValue;
 use SignerPHP\Infrastructure\PdfCore\Xref\CrossReferenceManager;
 
 /**
@@ -40,7 +41,7 @@ class Struct
      * Parse PDF structure (version, cross-references, trailer).
      *
      * ISO 32000 §7.5.2 places the version marker `%PDF-x.y` at file start, but some tools
-     * prepend UTF-8 BOM or binary bytes. Robustness principle (RFC 1122): scan first 1024
+     * prepend UTF-8 BOM or binary bytes. Robustness principle (RFC 1122): scan first 8192
      * bytes for `%PDF-` pattern instead of strict first-line matching. Consistent with
      * libpoppler, PDFium, Apache PDFBox.
      */
@@ -51,7 +52,7 @@ class Struct
             throw new Exception('Failed to get PDF version');
         }
 
-        $headerWindow = substr($buffer, 0, 1024);
+        $headerWindow = substr($buffer, 0, 8192);
         if (preg_match(self::REGEX_PDF_VERSION, $headerWindow, $matches) !== 1) {
             throw new Exception('PDF version not found');
         }
@@ -68,6 +69,11 @@ class Struct
         $xrefPos = $this->resolveXrefPosition($buffer);
 
         if ($xrefPos === null) {
+            $recovered = $this->recoverStructureWithoutXref($buffer, $pdfVersion, $versions);
+            if ($recovered !== null) {
+                return $recovered;
+            }
+
             throw new Exception('startxref not found');
         }
 
@@ -93,6 +99,35 @@ class Struct
             xrefTable: $xref->table,
             xrefPosition: $xrefPos,
             xrefVersion: $xref->minimumPdfVersion,
+            revisions: $versions,
+        );
+    }
+
+    /**
+     * @param  array<int, int>  $versions
+     */
+    private function recoverStructureWithoutXref(string $buffer, string $pdfVersion, array $versions): ?ParsedDocumentStructure
+    {
+        $trailer = $this->extractLastTrailerObject($buffer);
+        if ($trailer === null) {
+            $trailer = $this->extractSyntheticTrailerFromRootReference($buffer);
+        }
+
+        if ($trailer === null) {
+            return null;
+        }
+
+        $xrefTable = $this->buildSyntheticXrefTableFromObjectHeaders($buffer);
+        if ($xrefTable === []) {
+            return null;
+        }
+
+        return new ParsedDocumentStructure(
+            trailer: $trailer,
+            version: $pdfVersion,
+            xrefTable: $xrefTable,
+            xrefPosition: 0,
+            xrefVersion: $pdfVersion,
             revisions: $versions,
         );
     }
@@ -137,23 +172,27 @@ class Struct
     }
 
     /**
-     * Scan backward from EOF for the last standalone `xref` keyword (preceded by a newline).
-     * Also handles `xref` at the very start of the buffer (no preceding newline).
-     * Returns the byte offset of the `x` in `xref`, or null if not found.
+     * Scan backward from EOF for the last standalone `xref` keyword.
+     *
+     * `xref` may appear on its own line or after a non-letter separator on the
+     * same line (e.g. `endobj xref`). We intentionally reject matches embedded
+     * in alphabetic tokens such as `startxref`, and we keep only candidates
+     * that are followed by a `trailer` section.
      */
     private function findLastStandaloneXref(string $buffer): ?int
     {
-        foreach (["\nxref\n", "\nxref\r\n", "\r\nxref\n", "\r\nxref\r\n"] as $needle) {
-            $pos = strrpos($buffer, $needle);
-            if ($pos !== false) {
-                return $pos + 1; // skip the leading newline; point at 'x'
-            }
-        }
+        if (preg_match_all('/(?:^|[\r\n \t])(xref)(?:\r\n|\n)/m', $buffer, $matches, PREG_OFFSET_CAPTURE) > 0) {
+            $xrefMatches = $matches[1] ?? [];
+            for ($i = count($xrefMatches) - 1; $i >= 0; $i--) {
+                $candidate = $xrefMatches[$i];
+                if (! is_array($candidate)) {
+                    continue;
+                }
 
-        // Also handle 'xref' at the very start of the buffer (no preceding newline).
-        foreach (["xref\n", "xref\r\n"] as $needle) {
-            if (str_starts_with($buffer, $needle)) {
-                return 0;
+                $xrefOffset = $candidate[1];
+                if (strpos($buffer, 'trailer', $xrefOffset) !== false) {
+                    return $xrefOffset;
+                }
             }
         }
 
@@ -183,5 +222,113 @@ class Struct
         }
 
         return $lastObjectOffset;
+    }
+
+    private function extractLastTrailerObject(string $buffer): ?PDFValue
+    {
+        $trailerPos = strrpos($buffer, 'trailer');
+        if ($trailerPos === false) {
+            return null;
+        }
+
+        try {
+            return (new ObjectParser)->parseString($buffer, $trailerPos + strlen('trailer'));
+        } catch (Exception) {
+            return null;
+        }
+    }
+
+    private function extractSyntheticTrailerFromRootReference(string $buffer): ?PDFValue
+    {
+        if (preg_match_all('/\/Root\s+(\d+)\s+(\d+)\s+R\b/', $buffer, $matches, PREG_SET_ORDER) === 0) {
+            return null;
+        }
+
+        $lastRootReference = end($matches);
+        if (! is_array($lastRootReference)) {
+            return null;
+        }
+
+        $rootOidRaw = $lastRootReference[1] ?? null;
+        $rootGenerationRaw = $lastRootReference[2] ?? null;
+        if (! is_string($rootOidRaw) || ! is_string($rootGenerationRaw)) {
+            return null;
+        }
+
+        $rootOid = $this->parsePositiveIntWithinRange($rootOidRaw);
+        $rootGeneration = $this->parsePositiveIntWithinRange($rootGenerationRaw);
+        if ($rootOid === null || $rootGeneration === null || $rootOid === 0) {
+            return null;
+        }
+
+        $syntheticTrailer = sprintf('<< /Root %d %d R >>', $rootOid, $rootGeneration);
+
+        try {
+            return (new ObjectParser)->parseString($syntheticTrailer);
+        } catch (Exception) {
+            return null;
+        }
+    }
+
+    /**
+     * Build a synthetic xref table from object headers for malformed files that
+     * contain objects and trailer, but no xref/startxref section.
+     *
+     * @return array<int, int|array{stmoid:int,pos:int}|null>
+     */
+    private function buildSyntheticXrefTableFromObjectHeaders(string $buffer): array
+    {
+        if (preg_match_all('/(?:^|[\r\n])(\d+)\s+(\d+)\s+obj\b/m', $buffer, $matches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE) === 0) {
+            return [];
+        }
+
+        $xrefTable = [];
+        $metadata = [];
+
+        foreach ($matches as $match) {
+            $oidRaw = $match[1][0] ?? null;
+            $oidOffset = $match[1][1] ?? null;
+            $generationRaw = $match[2][0] ?? null;
+
+            if (! is_string($oidRaw) || ! is_int($oidOffset) || ! is_string($generationRaw)) {
+                continue;
+            }
+
+            $oid = $this->parsePositiveIntWithinRange($oidRaw);
+            $generation = $this->parsePositiveIntWithinRange($generationRaw);
+            if ($oid === null || $generation === null || $oid === 0) {
+                continue;
+            }
+
+            $current = $metadata[$oid] ?? null;
+            if (! is_array($current)
+                || $generation > $current['generation']
+                || ($generation === $current['generation'] && $oidOffset > $current['offset'])) {
+                $metadata[$oid] = ['generation' => $generation, 'offset' => $oidOffset];
+                $xrefTable[$oid] = $oidOffset;
+            }
+        }
+
+        ksort($xrefTable);
+
+        return $xrefTable;
+    }
+
+    private function parsePositiveIntWithinRange(string $number): ?int
+    {
+        if ($number === '' || ! ctype_digit($number)) {
+            return null;
+        }
+
+        $max = (string) PHP_INT_MAX;
+        if (strlen($number) > strlen($max)) {
+            return null;
+        }
+
+        if (strlen($number) === strlen($max) && strcmp($number, $max) > 0) {
+            return null;
+        }
+
+        return (int) $number;
     }
 }

--- a/src/Infrastructure/PdfCore/Struct.php
+++ b/src/Infrastructure/PdfCore/Struct.php
@@ -240,7 +240,7 @@ class Struct
 
     private function extractSyntheticTrailerFromRootReference(string $buffer): ?PDFValue
     {
-        if (preg_match_all('/\/Root\s+(\d+)\s+(\d+)\s+R\b/', $buffer, $matches, PREG_SET_ORDER) === 0) {
+        if (preg_match_all('/\/Root\s+([^\s]+)\s+([^\s]+)\s+R\b/', $buffer, $matches, PREG_SET_ORDER) === 0) {
             return null;
         }
 

--- a/tests/Infrastructure/PdfCore/PDFObjectTest.php
+++ b/tests/Infrastructure/PdfCore/PDFObjectTest.php
@@ -97,6 +97,46 @@ final class PDFObjectTest extends TestCase
         self::assertSame('hello world', $object->getStream(false));
     }
 
+    public function test_get_stream_decodes_flate_stream_with_long_non_whitespace_prefix(): void
+    {
+        // Some malformed fixtures leak long garbage prefixes before a valid Flate payload.
+        // Recovery must not be limited to tiny prefix lengths.
+        $payload = gzcompress('hello world');
+        self::assertIsString($payload);
+
+        $prefix = str_repeat('X', 128);
+        $object = new PDFObject(1, ['Filter' => new PDFValueSimple('/FlateDecode')]);
+        $object->setStream($prefix.$payload);
+
+        self::assertSame('hello world', $object->getStream(false));
+    }
+
+    public function test_get_stream_decodes_flate_stream_with_very_long_non_whitespace_prefix(): void
+    {
+        // Corpus-derived hardening: some streams contain kilobytes of junk bytes before
+        // the actual Flate payload. Decoder should recover without requiring exact offset.
+        $payload = gzcompress('hello world');
+        self::assertIsString($payload);
+
+        $prefix = str_repeat('X', 4096);
+        $object = new PDFObject(1, ['Filter' => new PDFValueSimple('/FlateDecode')]);
+        $object->setStream($prefix.$payload);
+
+        self::assertSame('hello world', $object->getStream(false));
+    }
+
+    public function test_get_stream_decodes_flate_stream_with_trailing_garbage_bytes(): void
+    {
+        // Some malformed PDFs include non-compressed bytes after a valid Flate payload.
+        $payload = gzcompress('hello world');
+        self::assertIsString($payload);
+
+        $object = new PDFObject(1, ['Filter' => new PDFValueSimple('/FlateDecode')]);
+        $object->setStream($payload."\nTRAILER");
+
+        self::assertSame('hello world', $object->getStream(false));
+    }
+
     public function test_get_stream_decodes_ascii85_then_flate_filter_chain(): void
     {
         $flatePayload = gzcompress('hello world');

--- a/tests/Unit/ObjectStreamResolverTest.php
+++ b/tests/Unit/ObjectStreamResolverTest.php
@@ -191,6 +191,58 @@ final class ObjectStreamResolverTest extends TestCase
         (new ObjectStreamResolver)->resolveFromObjectStream($document, 99, 0, 20);
     }
 
+    public function test_resolve_from_object_stream_ignores_extra_non_numeric_index_token(): void
+    {
+        $index = '20 0 junk ';
+        $objectStream = new PDFObject(99, [
+            'Type' => '/ObjStm',
+            'First' => strlen($index),
+            'N' => 1,
+        ]);
+        $objectStream->setStream($index.'<< /Type /Catalog >>');
+
+        $document = new class($objectStream) extends PdfDocument
+        {
+            public function __construct(private readonly PDFObject $objectStream) {}
+
+            public function findObject(int $oid): ?PDFObject
+            {
+                return $oid === 99 ? $this->objectStream : null;
+            }
+        };
+
+        $resolved = (new ObjectStreamResolver)->resolveFromObjectStream($document, 99, 0, 20);
+
+        self::assertSame('Catalog', $resolved['Type']->val());
+    }
+
+    public function test_resolve_from_object_stream_falls_back_to_lookup_by_object_id_when_position_mismatches(): void
+    {
+        $index = '9 0 20 5 ';
+        $payload = 'null << /Type /Catalog >>';
+        $objectStream = new PDFObject(99, [
+            'Type' => '/ObjStm',
+            'First' => strlen($index),
+            'N' => 2,
+        ]);
+        $objectStream->setStream($index.$payload);
+
+        $document = new class($objectStream) extends PdfDocument
+        {
+            public function __construct(private readonly PDFObject $objectStream) {}
+
+            public function findObject(int $oid): ?PDFObject
+            {
+                return $oid === 99 ? $this->objectStream : null;
+            }
+        };
+
+        $resolved = (new ObjectStreamResolver)->resolveFromObjectStream($document, 99, 0, 20);
+
+        self::assertSame(20, $resolved->getOid());
+        self::assertSame('Catalog', $resolved['Type']->val());
+    }
+
     public function test_resolve_from_object_stream_throws_when_object_position_is_out_of_range(): void
     {
         $objectStream = new PDFObject(99, [
@@ -211,9 +263,9 @@ final class ObjectStreamResolverTest extends TestCase
         };
 
         $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Object 20 not found in object stream 99.');
+        $this->expectExceptionMessage('Object 30 not found in object stream 99.');
 
-        (new ObjectStreamResolver)->resolveFromObjectStream($document, 99, 2, 20);
+        (new ObjectStreamResolver)->resolveFromObjectStream($document, 99, 2, 30);
     }
 
     public function test_resolve_from_object_stream_throws_for_invalid_inner_offset(): void

--- a/tests/Unit/ObjectStreamResolverTest.php
+++ b/tests/Unit/ObjectStreamResolverTest.php
@@ -166,6 +166,31 @@ final class ObjectStreamResolverTest extends TestCase
         (new ObjectStreamResolver)->resolveFromObjectStream($document, 99, 0, 20);
     }
 
+    public function test_resolve_from_object_stream_throws_when_n_is_not_numeric(): void
+    {
+        $objectStream = new PDFObject(99, [
+            'Type' => '/ObjStm',
+            'First' => 5,
+            'N' => 'abc',
+        ]);
+        $objectStream->setStream('20 0 << /Type /Catalog >>');
+
+        $document = new class($objectStream) extends PdfDocument
+        {
+            public function __construct(private readonly PDFObject $objectStream) {}
+
+            public function findObject(int $oid): ?PDFObject
+            {
+                return $oid === 99 ? $this->objectStream : null;
+            }
+        };
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Invalid object count in object stream 99');
+
+        (new ObjectStreamResolver)->resolveFromObjectStream($document, 99, 0, 20);
+    }
+
     public function test_resolve_from_object_stream_throws_for_invalid_index_pairs(): void
     {
         $objectStream = new PDFObject(99, [

--- a/tests/Unit/StructTest.php
+++ b/tests/Unit/StructTest.php
@@ -260,4 +260,123 @@ final class StructTest extends TestCase
         self::assertSame($offsetObj2, $structure->xrefTable[2]);
         self::assertSame($offsetObj3, $structure->xrefTable[3]);
     }
+
+    public function test_parse_throws_when_startxref_is_missing_and_trailer_is_invalid(): void
+    {
+        $pdf = "%PDF-1.4\n"
+            ."trailer\n<< /Root [ >>\n"
+            ."%%EOF\n";
+
+        $document = new PdfDocument;
+        $document->setBufferFromString($pdf);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('startxref not found');
+
+        Struct::new()
+            ->withPdfDocument($document)
+            ->parse();
+    }
+
+    public function test_parse_throws_when_startxref_is_missing_and_trailer_has_no_objects(): void
+    {
+        $pdf = "%PDF-1.4\n"
+            ."trailer\n<< /Root 1 0 R /Size 1 >>\n%%EOF\n";
+
+        $document = new PdfDocument;
+        $document->setBufferFromString($pdf);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('startxref not found');
+
+        Struct::new()
+            ->withPdfDocument($document)
+            ->parse();
+    }
+
+    public function test_parse_throws_when_synthetic_root_reference_is_zero_object(): void
+    {
+        $pdf = "%PDF-1.7\n"
+            ."0 0 obj <</Root 0 0 R>>\nendobj\n";
+
+        $document = new PdfDocument;
+        $document->setBufferFromString($pdf);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('startxref not found');
+
+        Struct::new()
+            ->withPdfDocument($document)
+            ->parse();
+    }
+
+    public function test_parse_throws_when_synthetic_root_reference_exceeds_int_range(): void
+    {
+        $overflowRoot = str_repeat('9', strlen((string) PHP_INT_MAX) + 1);
+        $pdf = "%PDF-1.7\n"
+            ."1 0 obj <</Root {$overflowRoot} 0 R>>\nendobj\n";
+
+        $document = new PdfDocument;
+        $document->setBufferFromString($pdf);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('startxref not found');
+
+        Struct::new()
+            ->withPdfDocument($document)
+            ->parse();
+    }
+
+    public function test_parse_skips_object_zero_in_synthetic_xref_recovery(): void
+    {
+        $pdf = "%PDF-1.4\n"
+            ."0 0 obj\n<< /Type /Ignored >>\nendobj\n"
+            ."1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n"
+            ."2 0 obj\n<< /Type /Pages /Kids [] /Count 0 >>\nendobj\n"
+            ."trailer\n<< /Root 1 0 R /Size 3 >>\n%%EOF\n";
+
+        $document = new PdfDocument;
+        $document->setBufferFromString($pdf);
+
+        $structure = Struct::new()
+            ->withPdfDocument($document)
+            ->parse();
+
+        self::assertArrayNotHasKey(0, $structure->xrefTable);
+        self::assertArrayHasKey(1, $structure->xrefTable);
+        self::assertArrayHasKey(2, $structure->xrefTable);
+    }
+
+    public function test_parse_throws_when_synthetic_root_has_same_length_but_is_greater_than_int_max(): void
+    {
+        $max = (string) PHP_INT_MAX;
+        $lastDigit = (int) substr($max, -1);
+        if ($lastDigit === 9) {
+            self::markTestSkipped('Cannot create same-length overflow value ending with digit 9.');
+        }
+
+        $sameLengthOverflow = substr($max, 0, -1).(string) ($lastDigit + 1);
+        $pdf = "%PDF-1.7\n"
+            ."1 0 obj <</Root {$sameLengthOverflow} 0 R>>\nendobj\n";
+
+        $document = new PdfDocument;
+        $document->setBufferFromString($pdf);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('startxref not found');
+
+        Struct::new()
+            ->withPdfDocument($document)
+            ->parse();
+    }
+
+    public function test_parse_positive_int_within_range_returns_null_for_non_digit_values(): void
+    {
+        $method = new \ReflectionMethod(Struct::class, 'parsePositiveIntWithinRange');
+        $method->setAccessible(true);
+
+        $result = $method->invoke(Struct::new(), 'abc');
+
+        self::assertNull($result);
+    }
 }

--- a/tests/Unit/StructTest.php
+++ b/tests/Unit/StructTest.php
@@ -370,13 +370,19 @@ final class StructTest extends TestCase
             ->parse();
     }
 
-    public function test_parse_positive_int_within_range_returns_null_for_non_digit_values(): void
+    public function test_parse_throws_when_synthetic_root_reference_contains_non_digit_object_number(): void
     {
-        $method = new \ReflectionMethod(Struct::class, 'parsePositiveIntWithinRange');
-        $method->setAccessible(true);
+        $pdf = "%PDF-1.7\n"
+            ."1 0 obj <</Root abc 0 R>>\nendobj\n";
 
-        $result = $method->invoke(Struct::new(), 'abc');
+        $document = new PdfDocument;
+        $document->setBufferFromString($pdf);
 
-        self::assertNull($result);
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('startxref not found');
+
+        Struct::new()
+            ->withPdfDocument($document)
+            ->parse();
     }
 }

--- a/tests/Unit/StructTest.php
+++ b/tests/Unit/StructTest.php
@@ -18,6 +18,7 @@ final class StructTest extends TestCase
         return [
             'no prefix (conforming)' => ["%PDF-1.4\nstartxref\n0\n%%EOF\n"],
             'UTF-8 BOM prefix (non-conforming)' => ["\xEF\xBB\xBF%PDF-1.4\nstartxref\n0\n%%EOF\n"],
+            'long binary prefix beyond first 1024 bytes' => [str_repeat("\x00", 1500)."%PDF-1.4\nstartxref\n0\n%%EOF\n"],
         ];
     }
 
@@ -131,6 +132,27 @@ final class StructTest extends TestCase
         self::assertSame(9, $structure->xrefPosition);
     }
 
+    public function test_parse_recovers_xref_when_keyword_is_after_space_on_same_line(): void
+    {
+        // Regression fixture: malformed PDFs may place `xref` after a space on the
+        // same line as a previous token (e.g. `endobj xref`).
+        $pdf = "%PDF-1.4\n1 0 obj\n<< /Type /Catalog >>\nendobj xref\n0 0\ntrailer\n<< /Size 1 >>\nstartxref\n%%EOF\n";
+        $document = new PdfDocument;
+        $document->setBufferFromString($pdf);
+
+        $structure = Struct::new()
+            ->withPdfDocument($document)
+            ->parse();
+
+        $xrefOffset = strpos($pdf, 'xref');
+        if ($xrefOffset === false) {
+            self::fail('Could not build same-line xref fixture.');
+        }
+
+        self::assertSame('PDF-1.4', $structure->version);
+        self::assertSame($xrefOffset, $structure->xrefPosition);
+    }
+
     public function test_parse_recovers_xref_at_buffer_start_with_crlf_keyword_when_startxref_is_missing_offset(): void
     {
         // Synthetic regression fixture from malformed PDFs: xref starts at byte 0 and uses
@@ -176,5 +198,66 @@ final class StructTest extends TestCase
         self::assertSame('PDF-1.5', $structure->version);
         self::assertSame($xrefOffset, $structure->xrefPosition);
         self::assertSame(9, $structure->xrefTable[1]);
+    }
+
+    public function test_parse_recovers_trailer_and_object_offsets_when_startxref_and_xref_are_missing(): void
+    {
+        // Regression fixture from corpus-like malformed files: no xref/startxref,
+        // but objects and trailer dictionary exist and are still parseable.
+        $pdf = "%PDF-1.4\n"
+            ."1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n"
+            ."2 0 obj\n<< /Type /Pages /Kids [] /Count 0 >>\nendobj\n"
+            ."trailer\n<< /Root 1 0 R /Size 3 >>\n%%EOF\n";
+
+        $offsetObj1 = strpos($pdf, '1 0 obj');
+        $offsetObj2 = strpos($pdf, '2 0 obj');
+        if ($offsetObj1 === false || $offsetObj2 === false) {
+            self::fail('Could not build no-xref trailer fallback fixture.');
+        }
+
+        $document = new PdfDocument;
+        $document->setBufferFromString($pdf);
+
+        $structure = Struct::new()
+            ->withPdfDocument($document)
+            ->parse();
+
+        self::assertSame('PDF-1.4', $structure->version);
+        self::assertSame(0, $structure->xrefPosition);
+        self::assertNotNull($structure->trailer);
+        self::assertSame($offsetObj1, $structure->xrefTable[1]);
+        self::assertSame($offsetObj2, $structure->xrefTable[2]);
+    }
+
+    public function test_parse_recovers_with_synthetic_trailer_when_root_reference_exists_without_trailer(): void
+    {
+        // Regression fixture based on malformed corpus files: no trailer/xref/startxref,
+        // but a /Root reference exists in an indirect object.
+        $pdf = "%PDF-1.7\n"
+            ."1 0 obj <</Type /Catalog /Pages 2 0 R>>\nendobj\n"
+            ."2 0 obj <</Type /Pages /Kids [3 0 R] /Count 1>>\nendobj\n"
+            ."3 0 obj <</Type /Page /Parent 2 0 R /MediaBox [0 0 10 10]>>\nendobj\n"
+            ."2147483647 0 obj <</Root 1 0 R>>\nendobj\n";
+
+        $offsetObj1 = strpos($pdf, '1 0 obj');
+        $offsetObj2 = strpos($pdf, '2 0 obj');
+        $offsetObj3 = strpos($pdf, '3 0 obj');
+        if ($offsetObj1 === false || $offsetObj2 === false || $offsetObj3 === false) {
+            self::fail('Could not build synthetic trailer fallback fixture.');
+        }
+
+        $document = new PdfDocument;
+        $document->setBufferFromString($pdf);
+
+        $structure = Struct::new()
+            ->withPdfDocument($document)
+            ->parse();
+
+        self::assertSame('PDF-1.7', $structure->version);
+        self::assertSame(0, $structure->xrefPosition);
+        self::assertNotNull($structure->trailer);
+        self::assertSame($offsetObj1, $structure->xrefTable[1]);
+        self::assertSame($offsetObj2, $structure->xrefTable[2]);
+        self::assertSame($offsetObj3, $structure->xrefTable[3]);
     }
 }


### PR DESCRIPTION
## Summary
This PR hardens PDF core parsing for malformed files and keeps history split into one signed commit per file.

## What changed
- Refactored and hardened Flate stream recovery logic in `PDFObject`.
- Added Flate regression tests for long/very-long prefixes and trailing garbage bytes.
- Hardened object-stream index resolution in `ObjectStreamResolver` (including oid-based fallback).
- Added object-stream regression coverage.
- Added `Struct` fallback for PDFs missing `xref/startxref`:
  - recover trailer directly when present,
  - synthesize xref table from object headers,
  - synthesize trailer from last `/Root N G R` reference when trailer is missing.
- Added regression tests for missing-`startxref` recovery paths.
