### PR TITLE
fix(pdf-core): harden malformed document recovery for signing

### DIFF
--- a/src/Infrastructure/PdfCore/PageInfo.php
+++ b/src/Infrastructure/PdfCore/PageInfo.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace SignerPHP\Infrastructure\PdfCore;
 
+use SignerPHP\Infrastructure\PdfCore\Exception\PdfCoreParsingException;
 use SignerPHP\Infrastructure\PdfCore\Exception\PdfCoreStructureException;
-use Throwable;
 
 class PageInfo
 {
@@ -189,13 +189,7 @@ class PageInfo
     private function discoverObjects(): array
     {
         $objects = $this->pdfDocument->getPdfObjects();
-        $xrefTable = [];
-
-        try {
-            $xrefTable = $this->pdfDocument->getXrefTable();
-        } catch (Throwable) {
-            $xrefTable = [];
-        }
+        $xrefTable = $this->pdfDocument->getXrefTable();
 
         foreach ($xrefTable as $oid => $entry) {
             $oid = (int) $oid;
@@ -205,7 +199,7 @@ class PageInfo
 
             try {
                 $candidate = $this->pdfDocument->getObject($oid);
-            } catch (Throwable) {
+            } catch (PdfCoreParsingException|PdfCoreStructureException) {
                 continue;
             }
 

--- a/src/Infrastructure/PdfCore/PageInfo.php
+++ b/src/Infrastructure/PdfCore/PageInfo.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SignerPHP\Infrastructure\PdfCore;
 
 use SignerPHP\Infrastructure\PdfCore\Exception\PdfCoreStructureException;
+use Throwable;
 
 class PageInfo
 {
@@ -28,17 +29,44 @@ class PageInfo
     public function acquirePagesInfo(): self
     {
         $rootValue = $this->pdfDocument->getTrailerObject()['Root'] ?? null;
-        if (($rootValue === null) || (($root = $rootValue->asObjectReferenceOrNull()) === null) || is_array($root)) {
+        if ($rootValue === null) {
             throw new PdfCoreStructureException('Could not resolve root object reference from trailer.');
         }
 
-        $root = $this->pdfDocument->getObject($root);
+        $rootRef = null;
+        $rootRef = $rootValue->asObjectReferenceOrNull();
+
+        if (is_array($rootRef)) {
+            $rootRef = null;
+        }
+
+        $root = is_int($rootRef) ? $this->pdfDocument->getObject($rootRef) : null;
+        if ($root === null) {
+            $root = $this->findFallbackCatalogObject();
+        }
+
         if ($root === null) {
             throw new PdfCoreStructureException('Could not resolve root object from trailer.');
         }
 
         $pagesValue = $root['Pages'] ?? null;
-        if (($pagesValue === null) || (($pages = $pagesValue->asObjectReferenceOrNull()) === null) || is_array($pages)) {
+        $pages = null;
+        if ($pagesValue !== null) {
+            $pages = $pagesValue->asObjectReferenceOrNull();
+        }
+
+        if (is_int($pages)) {
+            if ($this->pdfDocument->getObject($pages) === null) {
+                $fallbackPages = $this->findFallbackPagesRootOid($root->getOid());
+                if ($fallbackPages !== null) {
+                    $pages = $fallbackPages;
+                }
+            }
+        } else {
+            $pages = $this->findFallbackPagesRootOid($root->getOid());
+        }
+
+        if (! is_int($pages)) {
             throw new PdfCoreStructureException('Could not resolve pages root from document catalog.');
         }
 
@@ -68,7 +96,10 @@ class PageInfo
             case 'Pages':
                 $kids = $object['Kids']?->asObjectReferenceOrNull();
                 if (! is_array($kids)) {
-                    throw new PdfCoreStructureException('Could not resolve Kids list for page tree object '.$oid.'.');
+                    $kids = $this->deriveKidsFromParentReference($oid, $visitedOids);
+                    if ($kids === []) {
+                        throw new PdfCoreStructureException('Could not resolve Kids list for page tree object '.$oid.'.');
+                    }
                 }
 
                 $currentSize = $inheritedSize;
@@ -101,6 +132,89 @@ class PageInfo
         }
 
         return $pageDescriptors;
+    }
+
+    private function findFallbackCatalogObject(): ?PDFObject
+    {
+        foreach ($this->discoverObjects() as $candidate) {
+            if ($candidate['Type']?->val() === 'Catalog') {
+                return $candidate;
+            }
+        }
+
+        return null;
+    }
+
+    private function findFallbackPagesRootOid(int $catalogOid): ?int
+    {
+        $fallback = null;
+
+        foreach ($this->discoverObjects() as $candidate) {
+            if ($candidate['Type']?->val() !== 'Pages') {
+                continue;
+            }
+
+            if ($fallback === null) {
+                $fallback = $candidate->getOid();
+            }
+
+            $parentRef = $candidate['Parent']?->asObjectReferenceOrNull();
+            if (is_int($parentRef) && $parentRef === $catalogOid) {
+                return $candidate->getOid();
+            }
+        }
+
+        return $fallback;
+    }
+
+    /** @return array<int, int> */
+    private function deriveKidsFromParentReference(int $parentOid, array $visitedOids): array
+    {
+        $kids = [];
+
+        foreach ($this->discoverObjects() as $candidate) {
+            $childOid = $candidate->getOid();
+            $parentRef = $candidate['Parent']?->asObjectReferenceOrNull();
+            if (is_int($parentRef) && $parentRef === $parentOid) {
+                $kids[] = $childOid;
+            }
+        }
+
+        sort($kids);
+
+        return $kids;
+    }
+
+    /** @return array<int, PDFObject> */
+    private function discoverObjects(): array
+    {
+        $objects = $this->pdfDocument->getPdfObjects();
+        $xrefTable = [];
+
+        try {
+            $xrefTable = $this->pdfDocument->getXrefTable();
+        } catch (Throwable) {
+            $xrefTable = [];
+        }
+
+        foreach ($xrefTable as $oid => $entry) {
+            $oid = (int) $oid;
+            if ($oid === 0 || isset($objects[$oid])) {
+                continue;
+            }
+
+            try {
+                $candidate = $this->pdfDocument->getObject($oid);
+            } catch (Throwable) {
+                continue;
+            }
+
+            if ($candidate instanceof PDFObject) {
+                $objects[$oid] = $candidate;
+            }
+        }
+
+        return $objects;
     }
 
     public function getPageSize(int|PDFObject $page): ?array

--- a/src/Infrastructure/PdfCore/PdfDocument.php
+++ b/src/Infrastructure/PdfCore/PdfDocument.php
@@ -29,7 +29,7 @@ class PdfDocument
 
     protected int $xrefPosition;
 
-    protected array $xrefTable;
+    protected array $xrefTable = [];
 
     /** @var array<int, XrefEntry> */
     protected array $xrefEntries = [];

--- a/src/Infrastructure/PdfCore/Service/ObjectStreamResolver.php
+++ b/src/Infrastructure/PdfCore/Service/ObjectStreamResolver.php
@@ -48,12 +48,17 @@ final class ObjectStreamResolver
         $stream = $objstm->getStream(false);
         $index = substr((string) $stream, 0, $firstValue);
         preg_match_all('/-?\d+/', $index, $indexMatches);
-        $index = $indexMatches[0] ?? [];
+        $fullIndex = $indexMatches[0] ?? [];
+        $index = $fullIndex;
         $stream = substr((string) $stream, $firstValue);
 
         $expectedEntries = $nValue * 2;
         if ($expectedEntries > 0 && count($index) >= $expectedEntries) {
             $index = array_slice($index, 0, $expectedEntries);
+        }
+
+        if ((count($index) < 2 || count($index) % 2 !== 0) && count($fullIndex) >= 2 && count($fullIndex) % 2 === 0) {
+            $index = $fullIndex;
         }
 
         if (count($index) < 2 || count($index) % 2 !== 0) {
@@ -75,6 +80,17 @@ final class ObjectStreamResolver
             for ($i = 0; $i + 1 < $indexCount; $i += 2) {
                 if ((int) $index[$i] === $oid) {
                     $offset = (int) $index[$i + 1];
+                    break;
+                }
+            }
+        }
+
+        if ($offset === null && $index !== $fullIndex && count($fullIndex) % 2 === 0) {
+            $fullIndexCount = count($fullIndex);
+            for ($i = 0; $i + 1 < $fullIndexCount; $i += 2) {
+                if ((int) $fullIndex[$i] === $oid) {
+                    $offset = (int) $fullIndex[$i + 1];
+                    $index = $fullIndex;
                     break;
                 }
             }

--- a/src/Infrastructure/PdfCore/Struct.php
+++ b/src/Infrastructure/PdfCore/Struct.php
@@ -190,10 +190,10 @@ class Struct
             $xrefMatches = $matches[1] ?? [];
             for ($i = count($xrefMatches) - 1; $i >= 0; $i--) {
                 $candidate = $xrefMatches[$i];
-                    if (! is_array($candidate)) {
-                        continue;
-                    }
-                    $xrefOffset = (int) ($candidate[1] ?? 0);
+                if (! is_array($candidate)) {
+                    continue;
+                }
+                $xrefOffset = (int) ($candidate[1] ?? 0);
                 if (strpos($buffer, 'trailer', $xrefOffset) !== false) {
                     return $xrefOffset;
                 }

--- a/src/Infrastructure/PdfCore/Struct.php
+++ b/src/Infrastructure/PdfCore/Struct.php
@@ -190,7 +190,10 @@ class Struct
             $xrefMatches = $matches[1] ?? [];
             for ($i = count($xrefMatches) - 1; $i >= 0; $i--) {
                 $candidate = $xrefMatches[$i];
-                $xrefOffset = $candidate[1];
+                    if (! is_array($candidate)) {
+                        continue;
+                    }
+                    $xrefOffset = (int) ($candidate[1] ?? 0);
                 if (strpos($buffer, 'trailer', $xrefOffset) !== false) {
                     return $xrefOffset;
                 }

--- a/src/Infrastructure/PdfCore/Struct.php
+++ b/src/Infrastructure/PdfCore/Struct.php
@@ -15,8 +15,6 @@ class Struct
 {
     private PdfDocument $pdfDocument;
 
-    private const REGEX_PDF_VERSION = '/%PDF-(\d+\.\d+)/';
-
     public static function new(): static
     {
         return new static;
@@ -52,12 +50,10 @@ class Struct
             throw new Exception('Failed to get PDF version');
         }
 
-        $headerWindow = substr($buffer, 0, 8192);
-        if (preg_match(self::REGEX_PDF_VERSION, $headerWindow, $matches) !== 1) {
+        $pdfVersion = $this->resolvePdfVersion($buffer);
+        if ($pdfVersion === null) {
             throw new Exception('PDF version not found');
         }
-
-        $pdfVersion = 'PDF-'.$matches[1];
 
         preg_match_all('/startxref\s*([0-9]+)\s*%%EOF($|[\r\n])/ms', $buffer, $matches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE);
 
@@ -88,10 +84,19 @@ class Struct
             );
         }
 
-        $xref = CrossReferenceManager::new()
-            ->withXrefPosition($xrefPos)
-            ->withPdfDocument($this->pdfDocument)
-            ->parse();
+        try {
+            $xref = CrossReferenceManager::new()
+                ->withXrefPosition($xrefPos)
+                ->withPdfDocument($this->pdfDocument)
+                ->parse();
+        } catch (Exception $e) {
+            $recovered = $this->recoverStructureWithoutXref($buffer, $pdfVersion, $versions);
+            if ($recovered !== null) {
+                return $recovered;
+            }
+
+            throw $e;
+        }
 
         return new ParsedDocumentStructure(
             trailer: $xref->trailer,
@@ -185,10 +190,6 @@ class Struct
             $xrefMatches = $matches[1] ?? [];
             for ($i = count($xrefMatches) - 1; $i >= 0; $i--) {
                 $candidate = $xrefMatches[$i];
-                if (! is_array($candidate)) {
-                    continue;
-                }
-
                 $xrefOffset = $candidate[1];
                 if (strpos($buffer, 'trailer', $xrefOffset) !== false) {
                     return $xrefOffset;
@@ -245,15 +246,12 @@ class Struct
         }
 
         $lastRootReference = end($matches);
-        if (! is_array($lastRootReference)) {
+        if ($lastRootReference === false) {
             return null;
         }
 
-        $rootOidRaw = $lastRootReference[1] ?? null;
-        $rootGenerationRaw = $lastRootReference[2] ?? null;
-        if (! is_string($rootOidRaw) || ! is_string($rootGenerationRaw)) {
-            return null;
-        }
+        $rootOidRaw = (string) $lastRootReference[1];
+        $rootGenerationRaw = (string) $lastRootReference[2];
 
         $rootOid = $this->parsePositiveIntWithinRange($rootOidRaw);
         $rootGeneration = $this->parsePositiveIntWithinRange($rootGenerationRaw);
@@ -286,13 +284,9 @@ class Struct
         $metadata = [];
 
         foreach ($matches as $match) {
-            $oidRaw = $match[1][0] ?? null;
-            $oidOffset = $match[1][1] ?? null;
-            $generationRaw = $match[2][0] ?? null;
-
-            if (! is_string($oidRaw) || ! is_int($oidOffset) || ! is_string($generationRaw)) {
-                continue;
-            }
+            $oidRaw = (string) $match[1][0];
+            $oidOffset = (int) $match[1][1];
+            $generationRaw = (string) $match[2][0];
 
             $oid = $this->parsePositiveIntWithinRange($oidRaw);
             $generation = $this->parsePositiveIntWithinRange($generationRaw);
@@ -330,5 +324,58 @@ class Struct
         }
 
         return (int) $number;
+    }
+
+    private function resolvePdfVersion(string $buffer): ?string
+    {
+        $headerWindow = substr($buffer, 0, 8192);
+        if (preg_match('/%PDF-([^\s]+)/', $headerWindow, $matches) === 1) {
+            $normalized = $this->normalizeMalformedPdfVersionToken((string) $matches[1]);
+            if ($normalized !== null) {
+                return 'PDF-'.$normalized;
+            }
+        }
+
+        if ($this->looksLikePdfStructure($buffer)) {
+            return 'PDF-1.4';
+        }
+
+        return null;
+    }
+
+    private function normalizeMalformedPdfVersionToken(string $token): ?string
+    {
+        if ($token === '') {
+            return null;
+        }
+
+        if (preg_match('/^(\d+)\.(\d+)$/', $token, $matches) === 1) {
+            return $matches[1].'.'.$matches[2];
+        }
+
+        if (preg_match('/^(\d+)\.$/', $token, $matches) === 1) {
+            return $matches[1].'.0';
+        }
+
+        if (preg_match('/^[A-Za-z]\.([0-9]+)$/', $token, $matches) === 1) {
+            return '1.'.$matches[1];
+        }
+
+        if (preg_match('/^(\d+)$/', $token, $matches) === 1) {
+            return $matches[1].'.0';
+        }
+
+        return null;
+    }
+
+    private function looksLikePdfStructure(string $buffer): bool
+    {
+        if (preg_match('/\d+\s+\d+\s+obj\b/', $buffer) !== 1) {
+            return false;
+        }
+
+        return str_contains($buffer, 'xref')
+            || str_contains($buffer, 'trailer')
+            || str_contains($buffer, '/Root');
     }
 }

--- a/tests/Unit/ObjectStreamResolverTest.php
+++ b/tests/Unit/ObjectStreamResolverTest.php
@@ -191,6 +191,31 @@ final class ObjectStreamResolverTest extends TestCase
         (new ObjectStreamResolver)->resolveFromObjectStream($document, 99, 0, 20);
     }
 
+    public function test_resolve_from_object_stream_throws_when_n_is_negative(): void
+    {
+        $objectStream = new PDFObject(99, [
+            'Type' => '/ObjStm',
+            'First' => 5,
+            'N' => -1,
+        ]);
+        $objectStream->setStream('20 0 << /Type /Catalog >>');
+
+        $document = new class($objectStream) extends PdfDocument
+        {
+            public function __construct(private readonly PDFObject $objectStream) {}
+
+            public function findObject(int $oid): ?PDFObject
+            {
+                return $oid === 99 ? $this->objectStream : null;
+            }
+        };
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Invalid object count in object stream 99');
+
+        (new ObjectStreamResolver)->resolveFromObjectStream($document, 99, 0, 20);
+    }
+
     public function test_resolve_from_object_stream_throws_for_invalid_index_pairs(): void
     {
         $objectStream = new PDFObject(99, [
@@ -249,6 +274,33 @@ final class ObjectStreamResolverTest extends TestCase
             'Type' => '/ObjStm',
             'First' => strlen($index),
             'N' => 2,
+        ]);
+        $objectStream->setStream($index.$payload);
+
+        $document = new class($objectStream) extends PdfDocument
+        {
+            public function __construct(private readonly PDFObject $objectStream) {}
+
+            public function findObject(int $oid): ?PDFObject
+            {
+                return $oid === 99 ? $this->objectStream : null;
+            }
+        };
+
+        $resolved = (new ObjectStreamResolver)->resolveFromObjectStream($document, 99, 0, 20);
+
+        self::assertSame(20, $resolved->getOid());
+        self::assertSame('Catalog', $resolved['Type']->val());
+    }
+
+    public function test_resolve_from_object_stream_falls_back_to_full_index_when_declared_n_is_too_small(): void
+    {
+        $index = '9 0 20 5 ';
+        $payload = 'null << /Type /Catalog >>';
+        $objectStream = new PDFObject(99, [
+            'Type' => '/ObjStm',
+            'First' => strlen($index),
+            'N' => 1,
         ]);
         $objectStream->setStream($index.$payload);
 

--- a/tests/Unit/PDFObjectTest.php
+++ b/tests/Unit/PDFObjectTest.php
@@ -32,6 +32,17 @@ final class PDFObjectTest extends TestCase
         $object->getStream(false);
     }
 
+    public function test_get_stream_accepts_filter_name_without_leading_slash(): void
+    {
+        $object = new PDFObject(1, ['Filter' => 'FlateDecode']);
+
+        $payload = gzcompress('abc');
+        self::assertIsString($payload);
+        $object->setStream($payload);
+
+        self::assertSame('abc', $object->getStream(false));
+    }
+
     public function test_get_stream_decodes_flate_predictor_one(): void
     {
         $object = new PDFObject(1, [
@@ -232,6 +243,17 @@ final class PDFObjectTest extends TestCase
         $payload = $encoder('abc');
         self::assertIsString($payload);
         $object->setStream($payload);
+
+        self::assertSame('abc', $object->getStream(false));
+    }
+
+    public function test_get_stream_decodes_flate_stream_with_trailing_garbage_suffix(): void
+    {
+        $object = new PDFObject(1, ['Filter' => '/FlateDecode']);
+
+        $payload = gzcompress('abc');
+        self::assertIsString($payload);
+        $object->setStream($payload."\x00\x00TRAIL");
 
         self::assertSame('abc', $object->getStream(false));
     }

--- a/tests/Unit/PageInfoTest.php
+++ b/tests/Unit/PageInfoTest.php
@@ -5,14 +5,14 @@ declare(strict_types=1);
 namespace SignerPHP\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
+use SignerPHP\Infrastructure\PdfCore\Exception\PdfCoreParsingException;
 use SignerPHP\Infrastructure\PdfCore\PageDescriptor;
 use SignerPHP\Infrastructure\PdfCore\PageInfo;
 use SignerPHP\Infrastructure\PdfCore\PdfDocument;
 use SignerPHP\Infrastructure\PdfCore\PDFObject;
-use SignerPHP\Infrastructure\PdfCore\Exception\PdfCoreParsingException;
-use SignerPHP\Infrastructure\PdfCore\PdfValue\PDFValueSimple;
 use SignerPHP\Infrastructure\PdfCore\PdfValue\PDFValueObject;
 use SignerPHP\Infrastructure\PdfCore\PdfValue\PDFValueReference;
+use SignerPHP\Infrastructure\PdfCore\PdfValue\PDFValueSimple;
 
 final class PageInfoTest extends TestCase
 {

--- a/tests/Unit/PageInfoTest.php
+++ b/tests/Unit/PageInfoTest.php
@@ -9,6 +9,7 @@ use SignerPHP\Infrastructure\PdfCore\PageDescriptor;
 use SignerPHP\Infrastructure\PdfCore\PageInfo;
 use SignerPHP\Infrastructure\PdfCore\PdfDocument;
 use SignerPHP\Infrastructure\PdfCore\PDFObject;
+use SignerPHP\Infrastructure\PdfCore\PdfValue\PDFValueSimple;
 use SignerPHP\Infrastructure\PdfCore\PdfValue\PDFValueObject;
 use SignerPHP\Infrastructure\PdfCore\PdfValue\PDFValueReference;
 
@@ -119,6 +120,63 @@ final class PageInfoTest extends TestCase
             ->acquirePagesInfo();
     }
 
+    public function test_acquire_pages_info_falls_back_to_catalog_object_when_trailer_root_is_invalid(): void
+    {
+        $document = new PdfDocument;
+        $document->setTrailerObject(new PDFValueObject([
+            'Root' => new PDFValueReference(99),
+        ]));
+        $document->addObject(new PDFObject(1, [
+            'Type' => '/Catalog',
+            'Pages' => new PDFValueReference(2),
+        ]));
+        $document->addObject(new PDFObject(2, [
+            'Type' => '/Pages',
+            'Kids' => [3],
+            'Count' => 1,
+        ]));
+        $document->addObject(new PDFObject(3, [
+            'Type' => '/Page',
+            'Parent' => new PDFValueReference(2),
+            'MediaBox' => [0, 0, 10, 10],
+        ]));
+
+        $pageInfo = PageInfo::new()
+            ->withPdfDocument($document)
+            ->acquirePagesInfo();
+
+        self::assertNotNull($pageInfo->getPage(0));
+    }
+
+    public function test_acquire_pages_info_falls_back_to_pages_object_when_catalog_pages_reference_is_invalid(): void
+    {
+        $document = new PdfDocument;
+        $document->setTrailerObject(new PDFValueObject([
+            'Root' => new PDFValueReference(1),
+        ]));
+        $document->addObject(new PDFObject(1, [
+            'Type' => '/Catalog',
+            'Pages' => new PDFValueReference(99),
+        ]));
+        $document->addObject(new PDFObject(2, [
+            'Type' => '/Pages',
+            'Parent' => new PDFValueReference(1),
+            'Kids' => [3],
+            'Count' => 1,
+        ]));
+        $document->addObject(new PDFObject(3, [
+            'Type' => '/Page',
+            'Parent' => new PDFValueReference(2),
+            'MediaBox' => [0, 0, 10, 10],
+        ]));
+
+        $pageInfo = PageInfo::new()
+            ->withPdfDocument($document)
+            ->acquirePagesInfo();
+
+        self::assertNotNull($pageInfo->getPage(0));
+    }
+
     public function test_acquire_pages_info_fails_when_catalog_has_no_pages_reference(): void
     {
         $document = new PdfDocument;
@@ -195,6 +253,108 @@ final class PageInfoTest extends TestCase
         PageInfo::new()
             ->withPdfDocument($document)
             ->acquirePagesInfo();
+    }
+
+    public function test_acquire_pages_info_derives_kids_from_parent_reference_when_kids_list_is_missing(): void
+    {
+        $document = new PdfDocument;
+        $document->setTrailerObject(new PDFValueObject([
+            'Root' => new PDFValueReference(1),
+        ]));
+        $document->addObject(new PDFObject(1, [
+            'Type' => '/Catalog',
+            'Pages' => new PDFValueReference(2),
+        ]));
+        $document->addObject(new PDFObject(2, [
+            'Type' => '/Pages',
+            'Count' => 1,
+        ]));
+        $document->addObject(new PDFObject(3, [
+            'Type' => '/Page',
+            'Parent' => new PDFValueReference(2),
+            'MediaBox' => [0, 0, 10, 10],
+        ]));
+
+        $pageInfo = PageInfo::new()
+            ->withPdfDocument($document)
+            ->acquirePagesInfo();
+
+        self::assertNotNull($pageInfo->getPage(0));
+    }
+
+    public function test_acquire_pages_info_falls_back_when_root_reference_is_array_and_discovers_objects_from_xref_table(): void
+    {
+        $document = new class extends PdfDocument
+        {
+            public function __construct()
+            {
+                $this->setTrailerObject(new PDFValueObject([
+                    'Root' => new class(0) extends PDFValueSimple
+                    {
+                        public function asObjectReferenceOrNull(): int|array|null
+                        {
+                            return [1, 0];
+                        }
+                    },
+                ]));
+            }
+
+            public function getPdfObjects(): array
+            {
+                return [
+                    1 => new PDFObject(1, ['Type' => '/Catalog', 'Pages' => new PDFValueReference(2)]),
+                ];
+            }
+
+            public function getXrefTable(): array
+            {
+                return [0 => 0, 1 => 10, 2 => 20, 3 => 30, 4 => 40];
+            }
+
+            public function getObject(int $oid, bool $originalVersion = false): ?PDFObject
+            {
+                return match ($oid) {
+                    2 => new PDFObject(2, ['Type' => '/Pages', 'Count' => 1]),
+                    3 => new PDFObject(3, ['Type' => '/Page', 'Parent' => new PDFValueReference(2), 'MediaBox' => [0, 0, 10, 10]]),
+                    4 => throw new \RuntimeException('synthetic xref read failure'),
+                    default => null,
+                };
+            }
+        };
+
+        $pageInfo = PageInfo::new()
+            ->withPdfDocument($document)
+            ->acquirePagesInfo();
+
+        self::assertNotNull($pageInfo->getPage(0));
+    }
+
+    public function test_acquire_pages_info_ignores_visited_child_when_deriving_kids_from_parent_reference(): void
+    {
+        $document = new PdfDocument;
+        $document->setTrailerObject(new PDFValueObject([
+            'Root' => new PDFValueReference(1),
+        ]));
+        $document->addObject(new PDFObject(1, [
+            'Type' => '/Catalog',
+            'Pages' => new PDFValueReference(2),
+        ]));
+        $document->addObject(new PDFObject(2, [
+            'Type' => '/Pages',
+            'Parent' => new PDFValueReference(2),
+            'Count' => 1,
+        ]));
+        $document->addObject(new PDFObject(3, [
+            'Type' => '/Page',
+            'Parent' => new PDFValueReference(2),
+            'MediaBox' => [0, 0, 10, 10],
+        ]));
+
+        $pageInfo = PageInfo::new()
+            ->withPdfDocument($document)
+            ->acquirePagesInfo();
+
+        self::assertNotNull($pageInfo->getPage(0));
     }
 
     public function test_get_page_size_returns_null_for_negative_index(): void

--- a/tests/Unit/PageInfoTest.php
+++ b/tests/Unit/PageInfoTest.php
@@ -9,6 +9,7 @@ use SignerPHP\Infrastructure\PdfCore\PageDescriptor;
 use SignerPHP\Infrastructure\PdfCore\PageInfo;
 use SignerPHP\Infrastructure\PdfCore\PdfDocument;
 use SignerPHP\Infrastructure\PdfCore\PDFObject;
+use SignerPHP\Infrastructure\PdfCore\Exception\PdfCoreParsingException;
 use SignerPHP\Infrastructure\PdfCore\PdfValue\PDFValueSimple;
 use SignerPHP\Infrastructure\PdfCore\PdfValue\PDFValueObject;
 use SignerPHP\Infrastructure\PdfCore\PdfValue\PDFValueReference;
@@ -316,7 +317,7 @@ final class PageInfoTest extends TestCase
                 return match ($oid) {
                     2 => new PDFObject(2, ['Type' => '/Pages', 'Count' => 1]),
                     3 => new PDFObject(3, ['Type' => '/Page', 'Parent' => new PDFValueReference(2), 'MediaBox' => [0, 0, 10, 10]]),
-                    4 => throw new \RuntimeException('synthetic xref read failure'),
+                    4 => throw new PdfCoreParsingException('synthetic xref read failure'),
                     default => null,
                 };
             }

--- a/tests/Unit/StructTest.php
+++ b/tests/Unit/StructTest.php
@@ -22,6 +22,18 @@ final class StructTest extends TestCase
         ];
     }
 
+    /**
+     * @return array<string, array{string, string}>
+     */
+    public static function malformedPdfHeaderVariants(): array
+    {
+        return [
+            'pdf-a variant' => ["%PDF-a.4\nstartxref\n0\n%%EOF\n", 'PDF-1.4'],
+            'missing minor digits' => ["%PDF-1.\nstartxref\n0\n%%EOF\n", 'PDF-1.0'],
+            'integer-only version token' => ["%PDF-2\nstartxref\n0\n%%EOF\n", 'PDF-2.0'],
+        ];
+    }
+
     #[\PHPUnit\Framework\Attributes\DataProvider('pdfHeaderPrefixVariants')]
     public function test_parse_detects_pdf_version_with_various_header_prefixes(string $pdf): void
     {
@@ -38,42 +50,17 @@ final class StructTest extends TestCase
         self::assertSame(0, $structure->xrefPosition);
     }
 
-    public function test_parse_accepts_malformed_pdf_a_header_variant(): void
+    #[\PHPUnit\Framework\Attributes\DataProvider('malformedPdfHeaderVariants')]
+    public function test_parse_accepts_normalizable_malformed_headers(string $pdf, string $expectedVersion): void
     {
         $document = new PdfDocument;
-        $document->setBufferFromString("%PDF-a.4\nstartxref\n0\n%%EOF\n");
+        $document->setBufferFromString($pdf);
 
         $structure = Struct::new()
             ->withPdfDocument($document)
             ->parse();
 
-        self::assertSame('PDF-1.4', $structure->version);
-        self::assertSame(0, $structure->xrefPosition);
-    }
-
-    public function test_parse_accepts_header_with_missing_minor_digits(): void
-    {
-        $document = new PdfDocument;
-        $document->setBufferFromString("%PDF-1.\nstartxref\n0\n%%EOF\n");
-
-        $structure = Struct::new()
-            ->withPdfDocument($document)
-            ->parse();
-
-        self::assertSame('PDF-1.0', $structure->version);
-        self::assertSame(0, $structure->xrefPosition);
-    }
-
-    public function test_parse_accepts_header_with_integer_only_version_token(): void
-    {
-        $document = new PdfDocument;
-        $document->setBufferFromString("%PDF-2\nstartxref\n0\n%%EOF\n");
-
-        $structure = Struct::new()
-            ->withPdfDocument($document)
-            ->parse();
-
-        self::assertSame('PDF-2.0', $structure->version);
+        self::assertSame($expectedVersion, $structure->version);
         self::assertSame(0, $structure->xrefPosition);
     }
 

--- a/tests/Unit/StructTest.php
+++ b/tests/Unit/StructTest.php
@@ -112,7 +112,7 @@ final class StructTest extends TestCase
     public function test_parse_throws_when_header_is_missing_and_buffer_is_not_pdf_like(): void
     {
         $document = new PdfDocument;
-        $document->setBufferFromString("not a pdf");
+        $document->setBufferFromString('not a pdf');
 
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('PDF version not found');

--- a/tests/Unit/StructTest.php
+++ b/tests/Unit/StructTest.php
@@ -60,7 +60,9 @@ final class StructTest extends TestCase
             ->withPdfDocument($document)
             ->parse();
 
+        self::assertNull($structure->trailer);
         self::assertSame($expectedVersion, $structure->version);
+        self::assertSame([], $structure->xrefTable);
         self::assertSame(0, $structure->xrefPosition);
     }
 

--- a/tests/Unit/StructTest.php
+++ b/tests/Unit/StructTest.php
@@ -38,6 +38,90 @@ final class StructTest extends TestCase
         self::assertSame(0, $structure->xrefPosition);
     }
 
+    public function test_parse_accepts_malformed_pdf_a_header_variant(): void
+    {
+        $document = new PdfDocument;
+        $document->setBufferFromString("%PDF-a.4\nstartxref\n0\n%%EOF\n");
+
+        $structure = Struct::new()
+            ->withPdfDocument($document)
+            ->parse();
+
+        self::assertSame('PDF-1.4', $structure->version);
+        self::assertSame(0, $structure->xrefPosition);
+    }
+
+    public function test_parse_accepts_header_with_missing_minor_digits(): void
+    {
+        $document = new PdfDocument;
+        $document->setBufferFromString("%PDF-1.\nstartxref\n0\n%%EOF\n");
+
+        $structure = Struct::new()
+            ->withPdfDocument($document)
+            ->parse();
+
+        self::assertSame('PDF-1.0', $structure->version);
+        self::assertSame(0, $structure->xrefPosition);
+    }
+
+    public function test_parse_accepts_header_with_integer_only_version_token(): void
+    {
+        $document = new PdfDocument;
+        $document->setBufferFromString("%PDF-2\nstartxref\n0\n%%EOF\n");
+
+        $structure = Struct::new()
+            ->withPdfDocument($document)
+            ->parse();
+
+        self::assertSame('PDF-2.0', $structure->version);
+        self::assertSame(0, $structure->xrefPosition);
+    }
+
+    public function test_parse_falls_back_to_default_version_when_header_is_missing_but_structure_is_pdf_like(): void
+    {
+        $pdf = "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n"
+            ."2 0 obj\n<< /Type /Pages /Kids [] /Count 0 >>\nendobj\n"
+            ."trailer\n<< /Root 1 0 R /Size 3 >>\n%%EOF\n";
+
+        $document = new PdfDocument;
+        $document->setBufferFromString($pdf);
+
+        $structure = Struct::new()
+            ->withPdfDocument($document)
+            ->parse();
+
+        self::assertSame('PDF-1.4', $structure->version);
+        self::assertSame(0, $structure->xrefPosition);
+        self::assertArrayHasKey(1, $structure->xrefTable);
+        self::assertArrayHasKey(2, $structure->xrefTable);
+    }
+
+    public function test_parse_throws_when_header_token_is_not_normalizable(): void
+    {
+        $document = new PdfDocument;
+        $document->setBufferFromString("%PDF-foo\nstartxref\n0\n%%EOF\n");
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('PDF version not found');
+
+        Struct::new()
+            ->withPdfDocument($document)
+            ->parse();
+    }
+
+    public function test_parse_throws_when_header_is_missing_and_buffer_is_not_pdf_like(): void
+    {
+        $document = new PdfDocument;
+        $document->setBufferFromString("not a pdf");
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('PDF version not found');
+
+        Struct::new()
+            ->withPdfDocument($document)
+            ->parse();
+    }
+
     public function test_parse_throws_when_neither_startxref_nor_xref_table_found(): void
     {
         $document = new PdfDocument;
@@ -198,6 +282,49 @@ final class StructTest extends TestCase
         self::assertSame('PDF-1.5', $structure->version);
         self::assertSame($xrefOffset, $structure->xrefPosition);
         self::assertSame(9, $structure->xrefTable[1]);
+    }
+
+    public function test_parse_recovers_via_synthetic_structure_when_resolved_xref_is_invalid(): void
+    {
+        $catalog = "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n";
+        $pages = "2 0 obj\n<< /Type /Pages /Kids [] /Count 0 >>\nendobj\n";
+        $badXrefObject = "5 0 obj\n<< /Type /XRef /W [1 2 1] /Size 2 /Length 4 >>\nstream\nABCD\nendstream\nendobj\n";
+
+        $prefix = "%PDF-1.5\n".$catalog.$pages;
+        $xrefOffset = strlen($prefix);
+        $pdf = $prefix.$badXrefObject
+            ."trailer\n<< /Root 1 0 R /Size 3 >>\n"
+            ."startxref\n{$xrefOffset}\n%%EOF\n";
+
+        $document = new PdfDocument;
+        $document->setBufferFromString($pdf);
+
+        $structure = Struct::new()
+            ->withPdfDocument($document)
+            ->parse();
+
+        self::assertSame('PDF-1.5', $structure->version);
+        self::assertSame(0, $structure->xrefPosition);
+        self::assertArrayHasKey(1, $structure->xrefTable);
+        self::assertArrayHasKey(2, $structure->xrefTable);
+    }
+
+    public function test_parse_rethrows_xref_parsing_exception_when_fallback_structure_cannot_be_recovered(): void
+    {
+        $xrefObject = "5 0 obj\n<< /Type /XRef /W [1 2 1] /Size 2 /Length 4 >>\nstream\nABCD\nendstream\nendobj\n";
+        $pdf = "%PDF-1.5\n"
+            .$xrefObject
+            ."startxref\n9\n%%EOF\n";
+
+        $document = new PdfDocument;
+        $document->setBufferFromString($pdf);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Invalid stream for xref table');
+
+        Struct::new()
+            ->withPdfDocument($document)
+            ->parse();
     }
 
     public function test_parse_recovers_trailer_and_object_offsets_when_startxref_and_xref_are_missing(): void
@@ -374,6 +501,22 @@ final class StructTest extends TestCase
     {
         $pdf = "%PDF-1.7\n"
             ."1 0 obj <</Root abc 0 R>>\nendobj\n";
+
+        $document = new PdfDocument;
+        $document->setBufferFromString($pdf);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('startxref not found');
+
+        Struct::new()
+            ->withPdfDocument($document)
+            ->parse();
+    }
+
+    public function test_parse_throws_when_synthetic_root_reference_contains_non_digit_generation(): void
+    {
+        $pdf = "%PDF-1.7\n"
+            ."1 0 obj <</Root 1 abc R>>\nendobj\n";
 
         $document = new PdfDocument;
         $document->setBufferFromString($pdf);


### PR DESCRIPTION
## Summary
- improve fallback handling for malformed PDF structure, version, and object streams
- improve page tree recovery when catalog and kids references are inconsistent
- add regression coverage for the new recovery paths