### PR TITLE
fix(pdf-core): harden xref/version recovery for failing corpus cases

### DIFF
--- a/src/Infrastructure/PdfCore/PDFObject.php
+++ b/src/Infrastructure/PdfCore/PDFObject.php
@@ -287,7 +287,7 @@ endstream
         // If the compressed payload starts far from the stream start, blind linear probing
         // is too expensive. Scan a bounded prefix for plausible zlib/gzip headers first.
         $streamLength = strlen($stream);
-        $maxHeaderScan = min(65536, max(0, $streamLength - 2));
+        $maxHeaderScan = min(262144, max(0, $streamLength - 2));
         $attempts = 0;
 
         for ($offset = 1; $offset <= $maxHeaderScan; $offset++) {
@@ -305,7 +305,7 @@ endstream
             }
 
             // Keep this fallback bounded to avoid excessive decompression attempts.
-            if ($attempts >= 64) {
+            if ($attempts >= 256) {
                 break;
             }
         }

--- a/src/Infrastructure/PdfCore/PageInfo.php
+++ b/src/Infrastructure/PdfCore/PageInfo.php
@@ -208,6 +208,50 @@ class PageInfo
             }
         }
 
+        return $this->discoverObjectsFromRawBuffer($objects);
+    }
+
+    /**
+     * @param  array<int, PDFObject>  $objects
+     * @return array<int, PDFObject>
+     */
+    private function discoverObjectsFromRawBuffer(array $objects): array
+    {
+        try {
+            $buffer = $this->pdfDocument->getBuffer()->raw();
+        } catch (\Error) {
+            // Some tests create documents without a raw buffer; keep current discoveries.
+            return $objects;
+        }
+
+        if ($buffer === '') {
+            return $objects;
+        }
+
+        if (preg_match_all('/(?:^|[\r\n])(\d+)\s+(\d+)\s+obj\b/m', $buffer, $matches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE) === 0) {
+            return $objects;
+        }
+
+        foreach ($matches as $match) {
+            $oid = (int) ($match[1][0] ?? 0);
+            $offset = (int) ($match[1][1] ?? 0);
+
+            if ($oid === 0 || isset($objects[$oid])) {
+                continue;
+            }
+
+            try {
+                $candidate = $this->pdfDocument->findObjectAtOffset($offset, $oid);
+            } catch (PdfCoreParsingException|PdfCoreStructureException) {
+                continue;
+            }
+
+            if ($candidate instanceof PDFObject) {
+                $objects[$oid] = $candidate;
+                $this->pdfDocument->addObject($candidate);
+            }
+        }
+
         return $objects;
     }
 

--- a/src/Infrastructure/PdfCore/PageInfo.php
+++ b/src/Infrastructure/PdfCore/PageInfo.php
@@ -70,7 +70,16 @@ class PageInfo
             throw new PdfCoreStructureException('Could not resolve pages root from document catalog.');
         }
 
-        $this->pagesInfo = $this->getPageInfo($pages, null, []);
+        try {
+            $this->pagesInfo = $this->getPageInfo($pages, null, []);
+        } catch (PdfCoreStructureException $exception) {
+            $fallbackPages = $this->deriveLoosePageDescriptors();
+            if ($fallbackPages === []) {
+                throw $exception;
+            }
+
+            $this->pagesInfo = $fallbackPages;
+        }
 
         return $this;
     }
@@ -165,6 +174,29 @@ class PageInfo
         }
 
         return $fallback;
+    }
+
+    /** @return array<int, PageDescriptor> */
+    private function deriveLoosePageDescriptors(): array
+    {
+        $descriptors = [];
+
+        foreach ($this->discoverObjects() as $candidate) {
+            if ($candidate['Type']?->val() !== 'Page') {
+                continue;
+            }
+
+            $mediaBox = $candidate['MediaBox']?->val();
+            $pageSize = is_array($mediaBox) ? $mediaBox : [];
+            $descriptors[] = new PageDescriptor($candidate->getOid(), $pageSize);
+        }
+
+        usort(
+            $descriptors,
+            static fn (PageDescriptor $left, PageDescriptor $right): int => $left->id <=> $right->id
+        );
+
+        return $descriptors;
     }
 
     /** @return array<int, int> */

--- a/src/Infrastructure/PdfCore/PageInfo.php
+++ b/src/Infrastructure/PdfCore/PageInfo.php
@@ -46,7 +46,14 @@ class PageInfo
         }
 
         if ($root === null) {
-            throw new PdfCoreStructureException('Could not resolve root object from trailer.');
+            $fallbackPages = $this->deriveLoosePageDescriptors();
+            if ($fallbackPages === []) {
+                throw new PdfCoreStructureException('Could not resolve root object from trailer.');
+            }
+
+            $this->pagesInfo = $fallbackPages;
+
+            return $this;
         }
 
         $pagesValue = $root['Pages'] ?? null;

--- a/src/Infrastructure/PdfCore/PageInfo.php
+++ b/src/Infrastructure/PdfCore/PageInfo.php
@@ -217,12 +217,11 @@ class PageInfo
      */
     private function discoverObjectsFromRawBuffer(array $objects): array
     {
-        try {
-            $buffer = $this->pdfDocument->getBuffer()->raw();
-        } catch (\Error) {
-            // Some tests create documents without a raw buffer; keep current discoveries.
+        if (! $this->pdfDocument->hasBuffer()) {
             return $objects;
         }
+
+        $buffer = $this->pdfDocument->getBuffer()->raw();
 
         if ($buffer === '') {
             return $objects;

--- a/src/Infrastructure/PdfCore/PdfDocument.php
+++ b/src/Infrastructure/PdfCore/PdfDocument.php
@@ -138,6 +138,11 @@ class PdfDocument
         $this->buffer = new Buffer($buffer);
     }
 
+    public function hasBuffer(): bool
+    {
+        return isset($this->buffer);
+    }
+
     public function getPdfObjects(): array
     {
         return $this->pdfObjects;

--- a/src/Infrastructure/PdfCore/Service/ObjectStreamResolver.php
+++ b/src/Infrastructure/PdfCore/Service/ObjectStreamResolver.php
@@ -158,7 +158,8 @@ final class ObjectStreamResolver
             throw new PdfCoreStructureException('Could not resolve valid stream length for object '.$oid.'.');
         }
 
-        $object->setStream(substr($buffer, $streamOffset, $length));
+        $streamData = substr($buffer, $streamOffset, $length);
+        $object->setStream($this->recoverStreamDataWhenLengthIsShort($buffer, $streamOffset, $streamData, $object), true);
     }
 
     /**
@@ -226,5 +227,69 @@ final class ObjectStreamResolver
         }
 
         return null;
+    }
+
+    private function recoverStreamDataWhenLengthIsShort(string $buffer, int $streamOffset, string $declaredData, PDFObject $object): string
+    {
+        if (! $this->usesFlateDecode($object)) {
+            return $declaredData;
+        }
+
+        if ($this->canDecodeStream($object, $declaredData)) {
+            return $declaredData;
+        }
+
+        $endstreamPos = strpos($buffer, 'endstream', $streamOffset + strlen($declaredData));
+        if ($endstreamPos === false) {
+            return $declaredData;
+        }
+
+        $candidateRawLength = $endstreamPos - $streamOffset;
+        if ($candidateRawLength <= strlen($declaredData) || $candidateRawLength > strlen($declaredData) + 256) {
+            return $declaredData;
+        }
+
+        $candidate = substr($buffer, $streamOffset, $candidateRawLength);
+        $candidate = rtrim($candidate, "\r\n");
+        if ($candidate === '' || strlen($candidate) <= strlen($declaredData)) {
+            return $declaredData;
+        }
+
+        return $this->canDecodeStream($object, $candidate) ? $candidate : $declaredData;
+    }
+
+    private function usesFlateDecode(PDFObject $object): bool
+    {
+        $filter = $object['Filter'] ?? null;
+        if ($filter === null) {
+            return false;
+        }
+
+        $raw = is_object($filter) && method_exists($filter, 'val') ? $filter->val(true) : $filter;
+        if (is_array($raw)) {
+            foreach ($raw as $candidate) {
+                if ((string) $candidate === '/FlateDecode' || (string) $candidate === 'FlateDecode') {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        return (string) $raw === '/FlateDecode' || (string) $raw === 'FlateDecode';
+    }
+
+    private function canDecodeStream(PDFObject $object, string $streamData): bool
+    {
+        $probe = clone $object;
+        $probe->setStream($streamData, true);
+
+        try {
+            $probe->getStream(false);
+
+            return true;
+        } catch (PdfCoreParsingException|PdfCoreStructureException) {
+            return false;
+        }
     }
 }

--- a/src/Infrastructure/PdfCore/Service/PdfObjectReader.php
+++ b/src/Infrastructure/PdfCore/Service/PdfObjectReader.php
@@ -32,6 +32,11 @@ final class PdfObjectReader
         }
 
         if ($foundObjId !== $expectedObjId) {
+            $fallbackOffset = $this->findExpectedObjectHeaderOffset($buffer, (int) $expectedObjId, $offset);
+            if ($fallbackOffset !== null) {
+                return $this->objectFromBuffer($buffer, $expectedObjId, $fallbackOffset, $offsetEnd);
+            }
+
             throw new PdfCoreParsingException(sprintf(
                 'PDF structure is corrupt: found obj %d while searching for obj %s (at %s).',
                 $foundObjId,
@@ -69,6 +74,35 @@ final class PdfObjectReader
         $offsetEnd = $stream->getPosition();
 
         return new PDFObject($foundObjId, $objParsed, $foundObjGeneration);
+    }
+
+    private function findExpectedObjectHeaderOffset(string $buffer, int $expectedObjId, int $offset): ?int
+    {
+        if ($expectedObjId <= 0) {
+            return null;
+        }
+
+        $scanStart = max(0, $offset + 1);
+        $scanWindowLength = min(262144, max(0, strlen($buffer) - $scanStart));
+        if ($scanWindowLength === 0) {
+            return null;
+        }
+
+        $window = substr($buffer, $scanStart, $scanWindowLength);
+        $pattern = '/(?:^|[\r\n\x00\x09\x0C\x20])'.preg_quote((string) $expectedObjId, '/').'\s+\d+\s+obj\b/';
+        if (preg_match($pattern, $window, $match, PREG_OFFSET_CAPTURE) !== 1) {
+            return null;
+        }
+
+        $relativeOffset = (int) ($match[0][1] ?? -1);
+        if ($relativeOffset < 0) {
+            return null;
+        }
+
+        $header = (string) ($match[0][0] ?? '');
+        $leadingWhitespace = strlen($header) - strlen(ltrim($header, "\r\n\x00\x09\x0C\x20"));
+
+        return $scanStart + $relativeOffset + $leadingWhitespace;
     }
 
     public function parseObjectDefinitionString(string $objectDefinition, int $expectedOid): PDFObject

--- a/src/Infrastructure/PdfCore/Service/SignatureObjectAssembler.php
+++ b/src/Infrastructure/PdfCore/Service/SignatureObjectAssembler.php
@@ -100,8 +100,7 @@ final class SignatureObjectAssembler
         PDFValue $value,
         string $context,
         bool $fallbackWhenMissingReference = false,
-    ): PDFValueList
-    {
+    ): PDFValueList {
         if ($value instanceof PDFValueList) {
             return new PDFValueList($value->val());
         }

--- a/src/Infrastructure/PdfCore/Service/SignatureObjectAssembler.php
+++ b/src/Infrastructure/PdfCore/Service/SignatureObjectAssembler.php
@@ -44,7 +44,12 @@ final class SignatureObjectAssembler
                 ->generate();
         }
 
-        $annotationList = $this->resolveListValue($pdfDocument, $pageObject['Annots'] ?? new PDFValueList, 'annotation list');
+        $annotationList = $this->resolveListValue(
+            $pdfDocument,
+            $pageObject['Annots'] ?? new PDFValueList,
+            'annotation list',
+            fallbackWhenMissingReference: true,
+        );
         $annotationList->push(new PDFValueReference($annotationObject->getOid()));
         $pageObject['Annots'] = $annotationList;
 
@@ -90,7 +95,12 @@ final class SignatureObjectAssembler
         return $pageObject;
     }
 
-    private function resolveListValue(PdfDocument $pdfDocument, PDFValue $value, string $context): PDFValueList
+    private function resolveListValue(
+        PdfDocument $pdfDocument,
+        PDFValue $value,
+        string $context,
+        bool $fallbackWhenMissingReference = false,
+    ): PDFValueList
     {
         if ($value instanceof PDFValueList) {
             return new PDFValueList($value->val());
@@ -100,6 +110,10 @@ final class SignatureObjectAssembler
         if (($reference !== null) && (! is_array($reference))) {
             $listObject = $pdfDocument->getObject($reference);
             if ($listObject === null) {
+                if ($fallbackWhenMissingReference) {
+                    return new PDFValueList;
+                }
+
                 throw new PdfCoreStructureException('Could not resolve '.$context.' object');
             }
 

--- a/src/Infrastructure/PdfCore/Service/TrailerObjectResolver.php
+++ b/src/Infrastructure/PdfCore/Service/TrailerObjectResolver.php
@@ -34,7 +34,8 @@ final class TrailerObjectResolver
 
         $infoObject = $document->getObject($infoObjectId);
         if ($infoObject === null) {
-            throw new PdfCoreStructureException('Invalid info object');
+            // /Info is optional in PDF; ignore stale/broken references and continue.
+            return null;
         }
 
         return $infoObject;

--- a/src/Infrastructure/PdfCore/Struct.php
+++ b/src/Infrastructure/PdfCore/Struct.php
@@ -74,6 +74,11 @@ class Struct
         }
 
         if ($xrefPos === 0) {
+            $recovered = $this->recoverStructureWithoutXref($buffer, $pdfVersion, $versions);
+            if ($recovered !== null) {
+                return $recovered;
+            }
+
             return new ParsedDocumentStructure(
                 trailer: null,
                 version: $pdfVersion,
@@ -331,7 +336,7 @@ class Struct
 
     private function resolvePdfVersion(string $buffer): ?string
     {
-        $headerWindow = substr($buffer, 0, 8192);
+        $headerWindow = substr($buffer, 0, 65536);
         if (preg_match('/%PDF-([^\s]+)/', $headerWindow, $matches) === 1) {
             $normalized = $this->normalizeMalformedPdfVersionToken((string) $matches[1]);
             if ($normalized !== null) {
@@ -339,11 +344,33 @@ class Struct
             }
         }
 
+        $metaVersion = $this->extractVersionFromProducerMetadata($buffer);
+        if ($metaVersion !== null) {
+            return $metaVersion;
+        }
+
         if ($this->looksLikePdfStructure($buffer)) {
             return 'PDF-1.4';
         }
 
         return null;
+    }
+
+    private function extractVersionFromProducerMetadata(string $buffer): ?string
+    {
+        if (preg_match('/\/(?:Producer|Creator)\s*\(([^)]+)\)/', $buffer, $matches) !== 1) {
+            return null;
+        }
+
+        $metadataValue = $matches[1];
+
+        if (preg_match('/PDF[- ](\d+\.\d+)/', $metadataValue, $versionMatches) !== 1) {
+            return null;
+        }
+
+        $normalized = $this->normalizeMalformedPdfVersionToken($versionMatches[1]);
+
+        return $normalized !== null ? 'PDF-'.$normalized : null;
     }
 
     private function normalizeMalformedPdfVersionToken(string $token): ?string

--- a/src/Infrastructure/PdfCore/Xref/Service/XRef14Parser.php
+++ b/src/Infrastructure/PdfCore/Xref/Service/XRef14Parser.php
@@ -6,6 +6,7 @@ namespace SignerPHP\Infrastructure\PdfCore\Xref\Service;
 
 use SignerPHP\Infrastructure\PdfCore\Exception\PdfCoreParsingException;
 use SignerPHP\Infrastructure\PdfCore\Exception\PdfCoreStructureException;
+use SignerPHP\Infrastructure\PdfCore\PdfDocument;
 use SignerPHP\Infrastructure\PdfCore\PdfValue\PDFValue;
 use SignerPHP\Infrastructure\PdfCore\Trailer;
 use SignerPHP\Infrastructure\PdfCore\Xref\XrefParseResult;
@@ -230,7 +231,7 @@ final class XRef14Parser
             return $currentTable;
         }
 
-        $previous = $this->parse($buffer, (int) $prevPosition, $visitedPositions);
+        $previous = $this->parsePreviousSection($buffer, (int) $prevPosition, $visitedPositions);
 
         foreach ($previous->table as $objectId => $offset) {
             if (! isset($currentTable[$objectId])) {
@@ -239,5 +240,31 @@ final class XRef14Parser
         }
 
         return $currentTable;
+    }
+
+    private function parsePreviousSection(string $buffer, int $prevPosition, array $visitedPositions): XrefParseResult
+    {
+        if ($this->previousSectionLooksLikeXrefStream($buffer, $prevPosition)) {
+            $document = new PdfDocument;
+            $document->setBufferFromString($buffer);
+
+            return (new XRef15Parser)->parse($document, $prevPosition, $visitedPositions);
+        }
+
+        return $this->parse($buffer, $prevPosition, $visitedPositions);
+    }
+
+    private function previousSectionLooksLikeXrefStream(string $buffer, int $prevPosition): bool
+    {
+        $snippet = ltrim(substr($buffer, $prevPosition, 512));
+        if ($snippet === '') {
+            return false;
+        }
+
+        if (preg_match('/^\d+\s+\d+\s+obj\b/', $snippet) !== 1) {
+            return false;
+        }
+
+        return preg_match('/\/Type\s*\/XRef\b/', $snippet) === 1;
     }
 }

--- a/src/Infrastructure/PdfCore/Xref/Service/XRef15Parser.php
+++ b/src/Infrastructure/PdfCore/Xref/Service/XRef15Parser.php
@@ -134,9 +134,19 @@ final class XRef15Parser
     private function parsePreviousTable(PdfDocument $pdfDocument, int $prev, array $visitedPositions): array
     {
         $raw = $pdfDocument->getBuffer()->raw();
-        $trimmed = ltrim(substr($raw, $prev, 64));
+        $trimmed = ltrim(substr($raw, $prev, 256));
 
-        if (preg_match('/^\d+\s+\d+\s+obj\b/', $trimmed) === 1) {
+        if (preg_match('/^xref\b/', $trimmed) === 1) {
+            return (new XRef14Parser)->parse($raw, $prev, $visitedPositions)->table;
+        }
+
+        if (preg_match('/^(\d+\s+\d+\s+obj\b)(.*)$/s', $trimmed, $matches) === 1) {
+            $afterObjectHeader = ltrim((string) ($matches[2] ?? ''));
+
+            if (preg_match('/^xref\b/', $afterObjectHeader) === 1) {
+                return (new XRef14Parser)->parse($raw, $prev, $visitedPositions)->table;
+            }
+
             return $this->parse($pdfDocument, $prev, $visitedPositions)->table;
         }
 

--- a/tests/Unit/ObjectStreamResolverTest.php
+++ b/tests/Unit/ObjectStreamResolverTest.php
@@ -699,6 +699,28 @@ final class ObjectStreamResolverTest extends TestCase
         self::assertSame('DATA', $object->getStream());
     }
 
+    public function test_attach_object_stream_if_present_recovers_flate_stream_when_declared_length_is_short(): void
+    {
+        $decoded = '23 0 << /Type /Catalog >>';
+        $payload = gzcompress($decoded);
+        self::assertIsString($payload);
+
+        $declaredLength = strlen($payload) - 2;
+        $buffer = "1 0 obj\n<< /Filter /FlateDecode /Length {$declaredLength} >>\nstream\n"
+            .$payload
+            ."\nendstream\nendobj\n";
+
+        $document = new PdfDocument;
+        $document->setBufferFromString($buffer);
+
+        $offsetEnd = 0;
+        $object = $document->objectFromString(1, 0, $offsetEnd);
+
+        (new ObjectStreamResolver)->attachObjectStreamIfPresent($document, $object, $offsetEnd, 1);
+
+        self::assertSame($decoded, $object->getStream(false));
+    }
+
     #[DataProvider('provideStreamMarkerOffsets')]
     public function test_attach_object_stream_if_present_handles_different_stream_markers(
         string $buffer,

--- a/tests/Unit/ObjectStreamResolverTest.php
+++ b/tests/Unit/ObjectStreamResolverTest.php
@@ -765,95 +765,94 @@ final class ObjectStreamResolverTest extends TestCase
         self::assertSame('', $object->getStream());
     }
 
-    public function test_recover_stream_data_when_length_is_short_returns_declared_data_when_endstream_is_missing(): void
+    public function test_attach_object_stream_if_present_keeps_declared_data_when_endstream_is_missing_for_flate(): void
     {
-        $resolver = new ObjectStreamResolver;
-        $method = new \ReflectionMethod(ObjectStreamResolver::class, 'recoverStreamDataWhenLengthIsShort');
-        $method->setAccessible(true);
+        $declaredData = 'invalid-flate-data';
+        $buffer = "1 0 obj\n<< /Filter /FlateDecode /Length ".strlen($declaredData)." >>\nstream\n"
+            .$declaredData
+            ."\nendobj\n";
 
-        $object = new PDFObject(1, ['Filter' => '/FlateDecode']);
-        $declaredData = "invalid-flate-data";
-        $buffer = "stream\n{$declaredData}\ntruncated";
+        $document = new PdfDocument;
+        $document->setBufferFromString($buffer);
 
-        $result = $method->invoke($resolver, $buffer, 7, $declaredData, $object);
+        $offsetEnd = 0;
+        $object = $document->objectFromString(1, 0, $offsetEnd);
+        (new ObjectStreamResolver)->attachObjectStreamIfPresent($document, $object, $offsetEnd, 1);
 
-        self::assertSame($declaredData, $result);
+        self::assertSame($declaredData, $object->getStream());
     }
 
-    public function test_recover_stream_data_when_length_is_short_uses_decodable_candidate_until_endstream(): void
+    public function test_attach_object_stream_if_present_recovers_when_filter_array_contains_flate_decode(): void
     {
-        $resolver = new ObjectStreamResolver;
-        $method = new \ReflectionMethod(ObjectStreamResolver::class, 'recoverStreamDataWhenLengthIsShort');
-        $method->setAccessible(true);
-
         $decoded = '23 0 << /Type /Catalog >>';
-        $fullPayload = gzcompress($decoded);
-        self::assertIsString($fullPayload);
+        $payload = gzcompress($decoded);
+        self::assertIsString($payload);
 
-        $declaredData = substr($fullPayload, 0, max(1, strlen($fullPayload) - 10));
-        $buffer = $fullPayload."\nendstream\n";
-        $object = new PDFObject(1, ['Filter' => '/FlateDecode']);
+        $declaredLength = max(1, strlen($payload) - 10);
+        $buffer = "1 0 obj\n<< /Filter [/FlateDecode] /Length {$declaredLength} >>\nstream\n"
+            .$payload
+            ."\nendstream\nendobj\n";
 
-        $result = $method->invoke($resolver, $buffer, 0, $declaredData, $object);
+        $document = new PdfDocument;
+        $document->setBufferFromString($buffer);
 
-        self::assertNotSame($declaredData, $result);
+        $offsetEnd = 0;
+        $object = $document->objectFromString(1, 0, $offsetEnd);
+        (new ObjectStreamResolver)->attachObjectStreamIfPresent($document, $object, $offsetEnd, 1);
 
-        $probe = new PDFObject(10, ['Filter' => '/FlateDecode']);
-        $probe->setStream($result, true);
-        self::assertSame($decoded, $probe->getStream(false));
+        self::assertSame($decoded, $object->getStream(false));
     }
 
-    public function test_recover_stream_data_when_length_is_short_returns_declared_when_candidate_exceeds_guard_limit(): void
+    public function test_attach_object_stream_if_present_does_not_recover_when_filter_array_has_no_flate_decode(): void
     {
-        $resolver = new ObjectStreamResolver;
-        $method = new \ReflectionMethod(ObjectStreamResolver::class, 'recoverStreamDataWhenLengthIsShort');
-        $method->setAccessible(true);
+        $declaredData = 'NOT_ASCII85_PAYLOAD';
+        $buffer = "1 0 obj\n<< /Filter [/ASCII85Decode /LZWDecode] /Length ".strlen($declaredData)." >>\nstream\n"
+            .$declaredData
+            .str_repeat('A', 300)
+            ."\nendstream\nendobj\n";
 
+        $document = new PdfDocument;
+        $document->setBufferFromString($buffer);
+
+        $offsetEnd = 0;
+        $object = $document->objectFromString(1, 0, $offsetEnd);
+        (new ObjectStreamResolver)->attachObjectStreamIfPresent($document, $object, $offsetEnd, 1);
+
+        self::assertSame($declaredData, $object->getStream());
+    }
+
+    public function test_attach_object_stream_if_present_keeps_declared_data_when_candidate_trims_to_same_size(): void
+    {
         $declaredData = 'invalid-flate-data';
-        $buffer = $declaredData.str_repeat('A', 300).'endstream';
-        $object = new PDFObject(1, ['Filter' => '/FlateDecode']);
+        $buffer = "1 0 obj\n<< /Filter /FlateDecode /Length ".strlen($declaredData)." >>\nstream\n"
+            .$declaredData
+            ."\nendstream\nendobj\n";
 
-        $result = $method->invoke($resolver, $buffer, 0, $declaredData, $object);
+        $document = new PdfDocument;
+        $document->setBufferFromString($buffer);
 
-        self::assertSame($declaredData, $result);
+        $offsetEnd = 0;
+        $object = $document->objectFromString(1, 0, $offsetEnd);
+        (new ObjectStreamResolver)->attachObjectStreamIfPresent($document, $object, $offsetEnd, 1);
+
+        self::assertSame($declaredData, $object->getStream());
     }
 
-    public function test_recover_stream_data_when_length_is_short_returns_declared_when_trimmed_candidate_is_not_longer(): void
+    public function test_attach_object_stream_if_present_keeps_declared_data_when_flate_candidate_exceeds_guard_limit(): void
     {
-        $resolver = new ObjectStreamResolver;
-        $method = new \ReflectionMethod(ObjectStreamResolver::class, 'recoverStreamDataWhenLengthIsShort');
-        $method->setAccessible(true);
-
         $declaredData = 'invalid-flate-data';
-        $buffer = $declaredData."\nendstream";
-        $object = new PDFObject(1, ['Filter' => '/FlateDecode']);
+        $buffer = "1 0 obj\n<< /Filter /FlateDecode /Length ".strlen($declaredData)." >>\nstream\n"
+            .$declaredData
+            .str_repeat('A', 300)
+            ."\nendstream\nendobj\n";
 
-        $result = $method->invoke($resolver, $buffer, 0, $declaredData, $object);
+        $document = new PdfDocument;
+        $document->setBufferFromString($buffer);
 
-        self::assertSame($declaredData, $result);
-    }
+        $offsetEnd = 0;
+        $object = $document->objectFromString(1, 0, $offsetEnd);
+        (new ObjectStreamResolver)->attachObjectStreamIfPresent($document, $object, $offsetEnd, 1);
 
-    public function test_uses_flate_decode_handles_filter_array_values(): void
-    {
-        $resolver = new ObjectStreamResolver;
-        $method = new \ReflectionMethod(ObjectStreamResolver::class, 'usesFlateDecode');
-        $method->setAccessible(true);
-
-        $withoutFlate = new PDFObject(1, ['Filter' => ['/ASCII85Decode', '/LZWDecode']]);
-        $withFlate = new PDFObject(2, ['Filter' => ['/ASCII85Decode', '/FlateDecode']]);
-
-        self::assertFalse($method->invoke($resolver, $withoutFlate));
-        self::assertTrue($method->invoke($resolver, $withFlate));
-    }
-
-    public function test_can_decode_stream_returns_false_when_probe_throws_for_invalid_flate_data(): void
-    {
-        $resolver = new ObjectStreamResolver;
-        $method = new \ReflectionMethod(ObjectStreamResolver::class, 'canDecodeStream');
-        $method->setAccessible(true);
-
-        $object = new PDFObject(1, ['Filter' => '/FlateDecode']);
-
-        self::assertFalse($method->invoke($resolver, $object, 'invalid-flate-data'));
+        self::assertSame($declaredData, $object->getStream());
     }
 }

--- a/tests/Unit/ObjectStreamResolverTest.php
+++ b/tests/Unit/ObjectStreamResolverTest.php
@@ -764,4 +764,96 @@ final class ObjectStreamResolverTest extends TestCase
         // When no valid stream marker is found, attachObjectStreamIfPresent returns early with empty stream
         self::assertSame('', $object->getStream());
     }
+
+    public function test_recover_stream_data_when_length_is_short_returns_declared_data_when_endstream_is_missing(): void
+    {
+        $resolver = new ObjectStreamResolver;
+        $method = new \ReflectionMethod(ObjectStreamResolver::class, 'recoverStreamDataWhenLengthIsShort');
+        $method->setAccessible(true);
+
+        $object = new PDFObject(1, ['Filter' => '/FlateDecode']);
+        $declaredData = "invalid-flate-data";
+        $buffer = "stream\n{$declaredData}\ntruncated";
+
+        $result = $method->invoke($resolver, $buffer, 7, $declaredData, $object);
+
+        self::assertSame($declaredData, $result);
+    }
+
+    public function test_recover_stream_data_when_length_is_short_uses_decodable_candidate_until_endstream(): void
+    {
+        $resolver = new ObjectStreamResolver;
+        $method = new \ReflectionMethod(ObjectStreamResolver::class, 'recoverStreamDataWhenLengthIsShort');
+        $method->setAccessible(true);
+
+        $decoded = '23 0 << /Type /Catalog >>';
+        $fullPayload = gzcompress($decoded);
+        self::assertIsString($fullPayload);
+
+        $declaredData = substr($fullPayload, 0, max(1, strlen($fullPayload) - 10));
+        $buffer = $fullPayload."\nendstream\n";
+        $object = new PDFObject(1, ['Filter' => '/FlateDecode']);
+
+        $result = $method->invoke($resolver, $buffer, 0, $declaredData, $object);
+
+        self::assertNotSame($declaredData, $result);
+
+        $probe = new PDFObject(10, ['Filter' => '/FlateDecode']);
+        $probe->setStream($result, true);
+        self::assertSame($decoded, $probe->getStream(false));
+    }
+
+    public function test_recover_stream_data_when_length_is_short_returns_declared_when_candidate_exceeds_guard_limit(): void
+    {
+        $resolver = new ObjectStreamResolver;
+        $method = new \ReflectionMethod(ObjectStreamResolver::class, 'recoverStreamDataWhenLengthIsShort');
+        $method->setAccessible(true);
+
+        $declaredData = 'invalid-flate-data';
+        $buffer = $declaredData.str_repeat('A', 300).'endstream';
+        $object = new PDFObject(1, ['Filter' => '/FlateDecode']);
+
+        $result = $method->invoke($resolver, $buffer, 0, $declaredData, $object);
+
+        self::assertSame($declaredData, $result);
+    }
+
+    public function test_recover_stream_data_when_length_is_short_returns_declared_when_trimmed_candidate_is_not_longer(): void
+    {
+        $resolver = new ObjectStreamResolver;
+        $method = new \ReflectionMethod(ObjectStreamResolver::class, 'recoverStreamDataWhenLengthIsShort');
+        $method->setAccessible(true);
+
+        $declaredData = 'invalid-flate-data';
+        $buffer = $declaredData."\nendstream";
+        $object = new PDFObject(1, ['Filter' => '/FlateDecode']);
+
+        $result = $method->invoke($resolver, $buffer, 0, $declaredData, $object);
+
+        self::assertSame($declaredData, $result);
+    }
+
+    public function test_uses_flate_decode_handles_filter_array_values(): void
+    {
+        $resolver = new ObjectStreamResolver;
+        $method = new \ReflectionMethod(ObjectStreamResolver::class, 'usesFlateDecode');
+        $method->setAccessible(true);
+
+        $withoutFlate = new PDFObject(1, ['Filter' => ['/ASCII85Decode', '/LZWDecode']]);
+        $withFlate = new PDFObject(2, ['Filter' => ['/ASCII85Decode', '/FlateDecode']]);
+
+        self::assertFalse($method->invoke($resolver, $withoutFlate));
+        self::assertTrue($method->invoke($resolver, $withFlate));
+    }
+
+    public function test_can_decode_stream_returns_false_when_probe_throws_for_invalid_flate_data(): void
+    {
+        $resolver = new ObjectStreamResolver;
+        $method = new \ReflectionMethod(ObjectStreamResolver::class, 'canDecodeStream');
+        $method->setAccessible(true);
+
+        $object = new PDFObject(1, ['Filter' => '/FlateDecode']);
+
+        self::assertFalse($method->invoke($resolver, $object, 'invalid-flate-data'));
+    }
 }

--- a/tests/Unit/PDFObjectTest.php
+++ b/tests/Unit/PDFObjectTest.php
@@ -324,10 +324,6 @@ final class PDFObjectTest extends TestCase
         $object->getStream(false);
     }
 
-    // ----------------------------------------------------------------
-    // Corpus hardening regression tests
-    // ----------------------------------------------------------------
-
     /**
      * Valid zlib payload preceded by many bytes containing fake-looking zlib
      * headers that exhaust the scan attempt limit.

--- a/tests/Unit/PDFObjectTest.php
+++ b/tests/Unit/PDFObjectTest.php
@@ -345,11 +345,11 @@ final class PDFObjectTest extends TestCase
         // The header scan finds candidates at offsets 40, 80, …, 2560 → exactly
         // 64 attempts, all failing.  The 65th fake block at 2560 exhausts the
         // limit; the real payload at offset 2600 is never reached.
-        $fakeBlock = "\x78\x9C" . str_repeat("\xFF", 38); // 40 bytes: valid-looking header + garbage
+        $fakeBlock = "\x78\x9C".str_repeat("\xFF", 38); // 40 bytes: valid-looking header + garbage
         $garbage = str_repeat($fakeBlock, 65); // 2600 bytes, provides exactly 64 scan candidates
 
         $object = new PDFObject(1, ['Filter' => '/FlateDecode']);
-        $object->setStream($garbage . $validZlib);
+        $object->setStream($garbage.$validZlib);
 
         // Must decompress even after exhausting the old 64-attempt limit
         self::assertSame($expected, $object->getStream(false));

--- a/tests/Unit/PDFObjectTest.php
+++ b/tests/Unit/PDFObjectTest.php
@@ -323,4 +323,61 @@ final class PDFObjectTest extends TestCase
 
         $object->getStream(false);
     }
+
+    // ----------------------------------------------------------------
+    // Corpus hardening regression tests (problem #1: FlateDecode failures)
+    // ----------------------------------------------------------------
+
+    /**
+     * Problem #1 (20 corpus cases): Valid zlib payload preceded by many bytes
+     * containing fake-looking zlib headers that exhaust the scan attempt limit.
+     *
+     * tryInflateWithBoundedPrefixSkip() stops at 2048 bytes (payload beyond).
+     * tryInflateByHeaderScan() stops after 64 candidate attempts (64 fake
+     * headers precede the real one at offset 65*40 = 2600 bytes).
+     *
+     * Expected: decompressed content returned after increasing the attempt limit.
+     */
+    public function test_get_stream_decodes_flate_with_real_payload_after_64_fake_headers(): void
+    {
+        $expected = 'corpus-attempt-limit-payload';
+        $validZlib = gzcompress($expected);
+        self::assertIsString($validZlib);
+
+        // 65 fake valid zlib headers (0x78 0x9C), each padded to 40 bytes with
+        // garbage so decompression fails. Total: 65 × 40 = 2600 bytes.
+        // The header scan finds candidates at offsets 40, 80, …, 2560 → exactly
+        // 64 attempts, all failing.  The 65th fake block at 2560 exhausts the
+        // limit; the real payload at offset 2600 is never reached.
+        $fakeBlock = "\x78\x9C" . str_repeat("\xFF", 38); // 40 bytes: valid-looking header + garbage
+        $garbage = str_repeat($fakeBlock, 65); // 2600 bytes, provides exactly 64 scan candidates
+
+        $object = new PDFObject(1, ['Filter' => '/FlateDecode']);
+        $object->setStream($garbage . $validZlib);
+
+        // Must decompress even after exhausting the old 64-attempt limit
+        self::assertSame($expected, $object->getStream(false));
+    }
+
+    /**
+     * Problem #1 variant: Valid gzip payload buried after 70 000 bytes of binary
+     * junk. tryInflateByHeaderScan() only scans 65536 bytes, so the gzip magic
+     * bytes are never reached and inflation fails.
+     *
+     * Reproduce: 70 000-byte garbage prefix + valid gzdecode() payload.
+     * Expected: decompressed content returned successfully.
+     */
+    public function test_get_stream_decodes_flate_with_gzip_header_beyond_65536_byte_scan_window(): void
+    {
+        $expected = 'corpus-gzip-payload';
+        $validGzip = gzencode($expected);
+        self::assertIsString($validGzip);
+
+        $garbage = str_repeat("\x00\x01", 35000); // 70 000 bytes, no valid headers
+        $object = new PDFObject(1, ['Filter' => '/FlateDecode']);
+        $object->setStream($garbage.$validGzip);
+
+        // Must find and decompress the gzip payload beyond the 65536-byte window
+        self::assertSame($expected, $object->getStream(false));
+    }
 }

--- a/tests/Unit/PDFObjectTest.php
+++ b/tests/Unit/PDFObjectTest.php
@@ -325,12 +325,12 @@ final class PDFObjectTest extends TestCase
     }
 
     // ----------------------------------------------------------------
-    // Corpus hardening regression tests (problem #1: FlateDecode failures)
+    // Corpus hardening regression tests
     // ----------------------------------------------------------------
 
     /**
-     * Problem #1 (20 corpus cases): Valid zlib payload preceded by many bytes
-     * containing fake-looking zlib headers that exhaust the scan attempt limit.
+     * Valid zlib payload preceded by many bytes containing fake-looking zlib
+     * headers that exhaust the scan attempt limit.
      *
      * tryInflateWithBoundedPrefixSkip() stops at 2048 bytes (payload beyond).
      * tryInflateByHeaderScan() stops after 64 candidate attempts (64 fake
@@ -360,12 +360,12 @@ final class PDFObjectTest extends TestCase
     }
 
     /**
-     * Problem #1 variant: Valid gzip payload buried after 70 000 bytes of binary
-     * junk. tryInflateByHeaderScan() only scans 65536 bytes, so the gzip magic
-     * bytes are never reached and inflation fails.
+     * Valid gzip payload buried after 70 000 bytes of binary junk.
+     * tryInflateByHeaderScan() only scans 65536 bytes, so the gzip magic bytes
+     * are never reached and inflation fails.
      *
-     * Reproduce: 70 000-byte garbage prefix + valid gzdecode() payload.
-     * Expected: decompressed content returned successfully.
+     * Reproduce: 70 000-byte garbage prefix + valid gzencode() payload.
+     * Expected: decompressed content returned after widening the scan window.
      */
     public function test_get_stream_decodes_flate_with_gzip_header_beyond_65536_byte_scan_window(): void
     {

--- a/tests/Unit/PageInfoTest.php
+++ b/tests/Unit/PageInfoTest.php
@@ -233,6 +233,38 @@ final class PageInfoTest extends TestCase
             ->acquirePagesInfo();
     }
 
+    public function test_acquire_pages_info_falls_back_to_loose_page_objects_when_page_tree_is_unresolvable(): void
+    {
+        $document = new PdfDocument;
+        $document->setTrailerObject(new PDFValueObject([
+            'Root' => new PDFValueReference(1),
+        ]));
+        $document->addObject(new PDFObject(1, [
+            'Type' => '/Catalog',
+            'Pages' => new PDFValueReference(578),
+        ]));
+        $document->addObject(new PDFObject(3, [
+            'Type' => '/Page',
+            'MediaBox' => [0, 0, 10, 10],
+        ]));
+
+        $pageInfo = PageInfo::new()
+            ->withPdfDocument($document)
+            ->acquirePagesInfo();
+
+        self::assertNotNull($pageInfo->getPage(0));
+
+        $size = $pageInfo->getPageSize(0);
+        self::assertIsArray($size);
+        self::assertSame(
+            [0, 0, 10, 10],
+            array_map(
+                static fn (mixed $value): mixed => is_object($value) && method_exists($value, 'val') ? $value->val() : $value,
+                $size
+            )
+        );
+    }
+
     public function test_acquire_pages_info_fails_when_page_tree_type_is_missing(): void
     {
         $document = new PdfDocument;
@@ -440,12 +472,11 @@ final class PageInfoTest extends TestCase
             }
         };
 
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Could not resolve page tree object 2.');
-
-        PageInfo::new()
+        $pageInfo = PageInfo::new()
             ->withPdfDocument($document)
             ->acquirePagesInfo();
+
+        self::assertNotNull($pageInfo->getPage(0));
     }
 
     public function test_get_page_size_returns_null_for_negative_index(): void

--- a/tests/Unit/PageInfoTest.php
+++ b/tests/Unit/PageInfoTest.php
@@ -169,6 +169,24 @@ final class PageInfoTest extends TestCase
         self::assertNotNull($pageInfo->getPage(0));
     }
 
+    public function test_acquire_pages_info_falls_back_to_loose_pages_when_root_and_catalog_are_unresolvable(): void
+    {
+        $document = new PdfDocument;
+        $document->setTrailerObject(new PDFValueObject([
+            'Root' => new PDFValueReference(999),
+        ]));
+        $document->addObject(new PDFObject(7, [
+            'Type' => '/Page',
+            'MediaBox' => [0, 0, 20, 20],
+        ]));
+
+        $pageInfo = PageInfo::new()
+            ->withPdfDocument($document)
+            ->acquirePagesInfo();
+
+        self::assertNotNull($pageInfo->getPage(0));
+    }
+
     public function test_acquire_pages_info_falls_back_to_pages_object_when_catalog_pages_reference_is_invalid(): void
     {
         $document = new PdfDocument;

--- a/tests/Unit/PageInfoTest.php
+++ b/tests/Unit/PageInfoTest.php
@@ -378,6 +378,76 @@ final class PageInfoTest extends TestCase
         self::assertNotNull($pageInfo->getPage(0));
     }
 
+    public function test_acquire_pages_info_raw_buffer_discovery_returns_early_for_empty_buffer(): void
+    {
+        $document = new PdfDocument;
+        $document->setTrailerObject(new PDFValueObject([
+            'Root' => new PDFValueReference(99),
+        ]));
+        $document->setBufferFromString('');
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Could not resolve root object from trailer.');
+
+        PageInfo::new()
+            ->withPdfDocument($document)
+            ->acquirePagesInfo();
+    }
+
+    public function test_acquire_pages_info_raw_buffer_discovery_returns_early_without_object_matches(): void
+    {
+        $document = new PdfDocument;
+        $document->setTrailerObject(new PDFValueObject([
+            'Root' => new PDFValueReference(99),
+        ]));
+        $document->setBufferFromString("%PDF-1.7\nno indirect object here\n");
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Could not resolve root object from trailer.');
+
+        PageInfo::new()
+            ->withPdfDocument($document)
+            ->acquirePagesInfo();
+    }
+
+    public function test_acquire_pages_info_raw_buffer_discovery_skips_known_oid_and_parse_failures(): void
+    {
+        $document = new class extends PdfDocument
+        {
+            public function __construct()
+            {
+                $this->setTrailerObject(new PDFValueObject([
+                    'Root' => new PDFValueReference(99),
+                ]));
+                $this->setBufferFromString(
+                    "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n"
+                    ."2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n"
+                    ."3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 10 10] >>\nendobj\n"
+                );
+                $this->addObject(new PDFObject(1, [
+                    'Type' => '/Catalog',
+                    'Pages' => new PDFValueReference(2),
+                ]));
+            }
+
+            public function findObjectAtOffset(int $objectOffset, ?int $expectedOid = null): PDFObject
+            {
+                if ($expectedOid === 2) {
+                    throw new PdfCoreParsingException('synthetic parse failure');
+                }
+
+                return parent::findObjectAtOffset($objectOffset, $expectedOid);
+            }
+        };
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Could not resolve page tree object 2.');
+
+        PageInfo::new()
+            ->withPdfDocument($document)
+            ->acquirePagesInfo();
+    }
+
     public function test_get_page_size_returns_null_for_negative_index(): void
     {
         $document = new PdfDocument;

--- a/tests/Unit/PageInfoTest.php
+++ b/tests/Unit/PageInfoTest.php
@@ -149,6 +149,26 @@ final class PageInfoTest extends TestCase
         self::assertNotNull($pageInfo->getPage(0));
     }
 
+    public function test_acquire_pages_info_falls_back_to_catalog_discovered_from_raw_buffer_when_xref_cannot_resolve_root(): void
+    {
+        $document = new PdfDocument;
+        $document->setTrailerObject(new PDFValueObject([
+            'Root' => new PDFValueReference(99),
+        ]));
+        $document->setXrefTable([]);
+        $document->setBufferFromString(
+            "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n"
+            ."2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n"
+            ."3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 10 10] >>\nendobj\n"
+        );
+
+        $pageInfo = PageInfo::new()
+            ->withPdfDocument($document)
+            ->acquirePagesInfo();
+
+        self::assertNotNull($pageInfo->getPage(0));
+    }
+
     public function test_acquire_pages_info_falls_back_to_pages_object_when_catalog_pages_reference_is_invalid(): void
     {
         $document = new PdfDocument;

--- a/tests/Unit/PdfDocumentCoreTest.php
+++ b/tests/Unit/PdfDocumentCoreTest.php
@@ -15,6 +15,8 @@ final class PdfDocumentCoreTest extends TestCase
     public function test_getters_and_setters_roundtrip_core_state(): void
     {
         $document = new PdfDocument;
+        self::assertFalse($document->hasBuffer());
+
         $document->setPdfVersion('PDF-1.4');
         $document->setTrailerObject(new PDFValueObject(['Size' => 1]));
         $document->setXrefPosition(123);
@@ -30,6 +32,7 @@ final class PdfDocumentCoreTest extends TestCase
         self::assertSame([1 => 0], $document->getXrefTable());
         self::assertSame('1.4', $document->getXrefTableVersion());
         self::assertSame([10, 20], $document->getRevisions());
+        self::assertTrue($document->hasBuffer());
         self::assertSame('abc', $document->getBuffer()->raw());
         self::assertSame(7, $document->getMaxOid());
         self::assertCount(1, $document->getPdfObjects());
@@ -178,7 +181,7 @@ final class PdfDocumentCoreTest extends TestCase
         self::assertNotNull($infoObject['ModDate']);
     }
 
-    public function test_update_modify_date_throws_when_info_reference_targets_missing_object(): void
+    public function test_update_modify_date_replaces_stale_info_reference_with_new_info_object(): void
     {
         $document = new PdfDocument;
         $document->setTrailerObject(new PDFValueObject([
@@ -189,10 +192,21 @@ final class PdfDocumentCoreTest extends TestCase
             'Type' => '/Catalog',
         ]));
 
-        $this->expectException(\Exception::class);
-        $this->expectExceptionMessage('Invalid info object');
+        $result = $document->updateModifyDate(new \DateTime('2024-01-02T03:04:05+00:00'));
 
-        $document->updateModifyDate(new \DateTime('2024-01-02T03:04:05+00:00'));
+        self::assertTrue($result);
+
+        $infoReference = $document->getTrailerObject()['Info'];
+        self::assertNotNull($infoReference);
+        $newInfoOid = $infoReference->asObjectReferenceOrNull();
+        self::assertIsInt($newInfoOid);
+        self::assertNotSame(999, $newInfoOid);
+
+        $infoObject = $document->getObject($newInfoOid);
+        self::assertNotNull($infoObject);
+        self::assertSame('(Modifier with PHP Signer)', (string) $infoObject['Producer']);
+        self::assertNotNull($infoObject['CreationDate']);
+        self::assertNotNull($infoObject['ModDate']);
     }
 
     public function test_find_object_at_offset_decompresses_flatedecode_xref_stream(): void

--- a/tests/Unit/PdfObjectReaderTest.php
+++ b/tests/Unit/PdfObjectReaderTest.php
@@ -55,6 +55,20 @@ final class PdfObjectReaderTest extends TestCase
         $reader->objectFromBuffer($buffer, 9, 0, $offsetEnd);
     }
 
+    public function test_object_from_buffer_recovers_when_expected_object_header_appears_later_in_buffer(): void
+    {
+        $reader = new PdfObjectReader;
+        $buffer = "3 0 obj\n<< /Type /Catalog >>\nendobj\n"
+            ."9 0 obj\n<< /Type /Page >>\nendobj\n";
+
+        $offsetEnd = 0;
+        $object = $reader->objectFromBuffer($buffer, 9, 0, $offsetEnd);
+
+        self::assertSame(9, $object->getOid());
+        self::assertSame('Page', $object['Type']->val());
+        self::assertGreaterThan(0, $offsetEnd);
+    }
+
     public function test_object_from_buffer_accepts_null_expected_oid(): void
     {
         $reader = new PdfObjectReader;

--- a/tests/Unit/SignatureObjectAssemblerTest.php
+++ b/tests/Unit/SignatureObjectAssemblerTest.php
@@ -134,6 +134,56 @@ final class SignatureObjectAssemblerTest extends TestCase
         );
     }
 
+    public function test_assemble_throws_when_acroform_fields_reference_cannot_be_resolved(): void
+    {
+        $document = $this->buildSinglePageDocument();
+        $acroForm = $document->createObject([
+            'Fields' => new PDFValueReference(9996),
+        ]);
+
+        $root = $document->getObject(1);
+        self::assertNotNull($root);
+        $root['AcroForm'] = new PDFValueReference($acroForm->getOid());
+        $document->addObject($root);
+
+        $this->expectException(PdfCoreStructureException::class);
+        $this->expectExceptionMessage('Could not resolve AcroForm fields object');
+
+        (new SignatureObjectAssembler)->assemble(
+            $document,
+            SignatureAppearance::new()->withRect([10, 10, 100, 60]),
+            Metadata::new()
+        );
+    }
+
+    public function test_assemble_uses_resolved_acroform_object_fields(): void
+    {
+        $document = $this->buildSinglePageDocument();
+        $acroForm = $document->createObject([
+            'Fields' => new PDFValueObject([
+                'One' => new PDFValueReference(10),
+            ]),
+        ]);
+
+        $root = $document->getObject(1);
+        self::assertNotNull($root);
+        $root['AcroForm'] = new PDFValueReference($acroForm->getOid());
+        $document->addObject($root);
+
+        (new SignatureObjectAssembler)->assemble(
+            $document,
+            SignatureAppearance::new()->withRect([10, 10, 100, 60]),
+            Metadata::new()
+        );
+
+        $updatedRoot = $document->getObject(1);
+        self::assertNotNull($updatedRoot);
+        self::assertNotNull($updatedRoot['AcroForm']);
+        $resolvedAcroForm = $document->getObject($updatedRoot['AcroForm']->asObjectReferenceOrNull());
+        self::assertNotNull($resolvedAcroForm);
+        self::assertInstanceOf(PDFValueList::class, $resolvedAcroForm['Fields']);
+    }
+
     public function test_assemble_throws_when_perms_reference_cannot_be_resolved(): void
     {
         $document = $this->buildSinglePageDocument();

--- a/tests/Unit/SignatureObjectAssemblerTest.php
+++ b/tests/Unit/SignatureObjectAssemblerTest.php
@@ -197,22 +197,23 @@ final class SignatureObjectAssemblerTest extends TestCase
         self::assertCount(2, $updatedPage['Annots']->val());
     }
 
-    public function test_assemble_throws_when_annotation_reference_list_object_cannot_be_resolved(): void
+    public function test_assemble_recovers_when_annotation_reference_list_object_cannot_be_resolved(): void
     {
         $document = $this->buildSinglePageDocument();
         $page = $document->getObject(3);
         self::assertNotNull($page);
         $page['Annots'] = new PDFValueReference(9997);
         $document->addObject($page);
-
-        $this->expectException(PdfCoreStructureException::class);
-        $this->expectExceptionMessage('Could not resolve annotation list object');
-
         (new SignatureObjectAssembler)->assemble(
             $document,
             SignatureAppearance::new()->withRect([10, 10, 100, 60]),
             Metadata::new()
         );
+
+        $updatedPage = $document->getObject(3);
+        self::assertNotNull($updatedPage);
+        self::assertInstanceOf(PDFValueList::class, $updatedPage['Annots']);
+        self::assertCount(1, $updatedPage['Annots']->val());
     }
 
     public function test_assemble_uses_inline_object_as_acroform_when_reference_is_not_resolvable(): void

--- a/tests/Unit/StructTest.php
+++ b/tests/Unit/StructTest.php
@@ -519,12 +519,12 @@ final class StructTest extends TestCase
     }
 
     // ----------------------------------------------------------------
-    // Corpus hardening regression tests (problems found at 142/238 baseline)
+    // Corpus hardening regression tests
     // ----------------------------------------------------------------
 
     /**
-     * Problem #3 (8 corpus cases): PDF version marker sits beyond the first 8 KiB
-     * due to a large binary prefix prepended by the producing tool.
+     * PDF version marker sits beyond the first 8 KiB due to a large binary prefix
+     * prepended by the producing tool.
      *
      * Reproduce: 9 KiB of garbage bytes before %PDF-1.6.  resolvePdfVersion() only
      * scans 8192 bytes, so it misses the header and falls back to PDF-1.4 instead
@@ -550,8 +550,8 @@ final class StructTest extends TestCase
     }
 
     /**
-     * Problem #3 variant (producer metadata): Some corpus files have no %PDF- header
-     * at all but embed the version string inside a /Producer or /Creator value.
+     * Some files have no %PDF- header at all but embed the version string inside
+     * a /Producer or /Creator metadata value.
      *
      * Reproduce: buffer contains a /Producer entry that mentions "PDF-1.7" but no
      * %PDF- line.  Current code returns 'PDF-1.4' (generic fallback); it should
@@ -577,14 +577,13 @@ final class StructTest extends TestCase
     }
 
     /**
-     * Problem #5 (4 corpus cases): Trailer /Root is syntactically valid but the
-     * referenced object is absent from the xref table.  Code must locate the
-     * /Type /Catalog object by scanning object headers instead of blindly
-     * trusting the trailer's /Root reference.
+     * Trailer /Root is syntactically valid but the referenced object does not
+     * exist.  Code must locate the /Type /Catalog object by scanning object
+     * headers instead of blindly trusting the trailer's /Root reference.
      *
      * Reproduce: trailer /Root 99 0 R but no object 99 exists; object 1 has
-     * /Type /Catalog.  Current extractSyntheticTrailerFromRootReference() only
-     * looks for /Root refs in the buffer, not for /Type /Catalog directly.
+     * /Type /Catalog.  extractSyntheticTrailerFromRootReference() only looks for
+     * /Root refs in the buffer, not for /Type /Catalog directly.
      */
     public function test_parse_synthesizes_root_from_catalog_type_object_when_trailer_root_is_invalid(): void
     {

--- a/tests/Unit/StructTest.php
+++ b/tests/Unit/StructTest.php
@@ -518,10 +518,6 @@ final class StructTest extends TestCase
             ->parse();
     }
 
-    // ----------------------------------------------------------------
-    // Corpus hardening regression tests
-    // ----------------------------------------------------------------
-
     /**
      * PDF version marker sits beyond the first 8 KiB due to a large binary prefix
      * prepended by the producing tool.

--- a/tests/Unit/StructTest.php
+++ b/tests/Unit/StructTest.php
@@ -517,4 +517,97 @@ final class StructTest extends TestCase
             ->withPdfDocument($document)
             ->parse();
     }
+
+    // ----------------------------------------------------------------
+    // Corpus hardening regression tests (problems found at 142/238 baseline)
+    // ----------------------------------------------------------------
+
+    /**
+     * Problem #3 (8 corpus cases): PDF version marker sits beyond the first 8 KiB
+     * due to a large binary prefix prepended by the producing tool.
+     *
+     * Reproduce: 9 KiB of garbage bytes before %PDF-1.6.  resolvePdfVersion() only
+     * scans 8192 bytes, so it misses the header and falls back to PDF-1.4 instead
+     * of returning the actual version encoded in the file.
+     */
+    public function test_parse_detects_exact_pdf_version_when_header_marker_is_beyond_8kb(): void
+    {
+        $prefix = str_repeat("\x00", 9000); // 9 KiB of nulls before the header
+        $body = "1 0 obj <</Type /Catalog /Pages 2 0 R>> endobj\n"
+            ."2 0 obj <</Type /Pages /Kids [] /Count 0>> endobj\n"
+            ."trailer <</Root 1 0 R /Size 3>>\nstartxref\n0\n%%EOF\n";
+        $pdf = $prefix."%PDF-1.6\n".$body;
+
+        $document = new PdfDocument;
+        $document->setBufferFromString($pdf);
+
+        $structure = Struct::new()
+            ->withPdfDocument($document)
+            ->parse();
+
+        // Must detect the actual version in the file, NOT fall back to 1.4
+        self::assertSame('PDF-1.6', $structure->version);
+    }
+
+    /**
+     * Problem #3 variant (producer metadata): Some corpus files have no %PDF- header
+     * at all but embed the version string inside a /Producer or /Creator value.
+     *
+     * Reproduce: buffer contains a /Producer entry that mentions "PDF-1.7" but no
+     * %PDF- line.  Current code returns 'PDF-1.4' (generic fallback); it should
+     * extract the version from the metadata instead.
+     */
+    public function test_parse_infers_version_from_producer_metadata_when_header_is_absent(): void
+    {
+        // No %PDF- header; version only visible in /Producer metadata.
+        $pdf = "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n"
+            ."2 0 obj\n<< /Type /Pages /Kids [] /Count 0 >>\nendobj\n"
+            ."3 0 obj\n<< /Type /Info /Producer (Acrobat Distiller 9.0 PDF 1.7) >>\nendobj\n"
+            ."trailer\n<< /Root 1 0 R /Info 3 0 R /Size 4 >>\nstartxref\n0\n%%EOF\n";
+
+        $document = new PdfDocument;
+        $document->setBufferFromString($pdf);
+
+        $structure = Struct::new()
+            ->withPdfDocument($document)
+            ->parse();
+
+        // Must extract version from /Producer, NOT fall back to 1.4
+        self::assertSame('PDF-1.7', $structure->version);
+    }
+
+    /**
+     * Problem #5 (4 corpus cases): Trailer /Root is syntactically valid but the
+     * referenced object is absent from the xref table.  Code must locate the
+     * /Type /Catalog object by scanning object headers instead of blindly
+     * trusting the trailer's /Root reference.
+     *
+     * Reproduce: trailer /Root 99 0 R but no object 99 exists; object 1 has
+     * /Type /Catalog.  Current extractSyntheticTrailerFromRootReference() only
+     * looks for /Root refs in the buffer, not for /Type /Catalog directly.
+     */
+    public function test_parse_synthesizes_root_from_catalog_type_object_when_trailer_root_is_invalid(): void
+    {
+        $pdf = "%PDF-1.4\n"
+            ."1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n"
+            ."2 0 obj\n<< /Type /Pages /Kids [] /Count 0 >>\nendobj\n"
+            // xref with deliberate bad offsets (0) to force xref parse failure
+            ."xref\n0 3\n"
+            ."0000000000 65535 f\n"
+            ."0000000000 00000 n\n"
+            ."0000000000 00000 n\n"
+            ."trailer\n<< /Root 99 0 R /Size 3 >>\n"
+            ."startxref\n0\n%%EOF\n";
+
+        $document = new PdfDocument;
+        $document->setBufferFromString($pdf);
+
+        $structure = Struct::new()
+            ->withPdfDocument($document)
+            ->parse();
+
+        // Should synthesize a valid trailer pointing to the /Type /Catalog object
+        self::assertSame('PDF-1.4', $structure->version);
+        self::assertNotNull($structure->trailer);
+    }
 }

--- a/tests/Unit/TrailerObjectResolverTest.php
+++ b/tests/Unit/TrailerObjectResolverTest.php
@@ -38,15 +38,14 @@ final class TrailerObjectResolverTest extends TestCase
         (new TrailerObjectResolver)->resolveRootObject($document);
     }
 
-    public function test_resolve_info_object_throws_when_target_object_is_missing(): void
+    public function test_resolve_info_object_returns_null_when_target_object_is_missing(): void
     {
         $document = new PdfDocument;
         $document->setTrailerObject(new PDFValueObject(['Info' => new PDFValueReference(10)]));
 
-        $this->expectException(PdfCoreStructureException::class);
-        $this->expectExceptionMessage('Invalid info object');
+        $resolved = (new TrailerObjectResolver)->resolveInfoObject($document);
 
-        (new TrailerObjectResolver)->resolveInfoObject($document);
+        self::assertNull($resolved);
     }
 
     public function test_resolve_info_object_returns_null_when_reference_is_missing(): void

--- a/tests/Unit/XRef14ParserTest.php
+++ b/tests/Unit/XRef14ParserTest.php
@@ -23,6 +23,26 @@ final class XRef14ParserTest extends TestCase
         self::assertSame('1.4', $result->minimumPdfVersion);
     }
 
+    public function test_parse_merges_previous_xref_stream_when_prev_points_to_xref_object(): void
+    {
+        $previousEntries = chr(1).pack('n', 10).chr(0);
+        $previous = "14 0 obj\n"
+            ."<< /Type /XRef /W [1 2 1] /Size 2 /Index [1 1] /Length 4 >>\n"
+            ."stream\n"
+            .$previousEntries."\n"
+            ."endstream\n"
+            ."endobj\n";
+
+        $current = "xref\n2 1\n0000000020 00000 n \ntrailer\n<< /Size 3 /Prev 0 >>\nstartxref\n123\n%%EOF\n";
+        $buffer = $previous.$current;
+        $currentPos = strlen($previous);
+
+        $result = (new XRef14Parser)->parse($buffer, $currentPos);
+
+        self::assertSame(10, $result->table[1]);
+        self::assertSame(20, $result->table[2]);
+    }
+
     public function test_parse_throws_when_xref_tag_is_missing_at_position(): void
     {
         $buffer = "no-tag-here\ntrailer\n<< /Size 1 >>\nstartxref\n0\n%%EOF\n";

--- a/tests/Unit/XRef15ParserTest.php
+++ b/tests/Unit/XRef15ParserTest.php
@@ -177,7 +177,8 @@ final class XRef15ParserTest extends TestCase
         $currentObject['Prev'] = $prevPosition;
 
         // The document stub: offset 0 is not a real xref stream object.
-        $document = new class($currentObject, $classicXrefBuffer) extends PdfDocument {
+        $document = new class($currentObject, $classicXrefBuffer) extends PdfDocument
+        {
             public function __construct(
                 private readonly PDFObject $current,
                 string $buffer

--- a/tests/Unit/XRef15ParserTest.php
+++ b/tests/Unit/XRef15ParserTest.php
@@ -143,10 +143,6 @@ final class XRef15ParserTest extends TestCase
         self::assertSame(0, $value);
     }
 
-    // ----------------------------------------------------------------
-    // Corpus hardening regression tests
-    // ----------------------------------------------------------------
-
     /**
      * /Prev in a 1.5 xref stream points to a classic xref table, but the bytes
      * at that offset look like `N G obj` (object header).

--- a/tests/Unit/XRef15ParserTest.php
+++ b/tests/Unit/XRef15ParserTest.php
@@ -162,7 +162,8 @@ final class XRef15ParserTest extends TestCase
             ."xref\n0 2\n"
             ."0000000000 65535 f\n"
             ."0000000060 00000 n\n"
-            ."trailer << /Size 2 /Root 1 0 R >>\n";
+            ."trailer << /Size 2 /Root 1 0 R >>\n"
+            ."startxref\n0\n%%EOF\n";
 
         $prevPosition = 0; // /Prev points here (starts with `1 0 obj`)
 
@@ -175,7 +176,7 @@ final class XRef15ParserTest extends TestCase
         );
         $currentObject['Prev'] = $prevPosition;
 
-        // The document stub: objectFromString() throws for offset 0 (not a real xref stream)
+        // The document stub: offset 0 is not a real xref stream object.
         $document = new class($currentObject, $classicXrefBuffer) extends PdfDocument {
             public function __construct(
                 private readonly PDFObject $current,
@@ -195,6 +196,10 @@ final class XRef15ParserTest extends TestCase
 
             public function findObjectAtOffset(int $objectOffset, ?int $expectedOid = null): PDFObject
             {
+                if ($objectOffset === 0) {
+                    throw new \Exception('Not a valid xref stream object at offset 0');
+                }
+
                 return $this->current;
             }
         };

--- a/tests/Unit/XRef15ParserTest.php
+++ b/tests/Unit/XRef15ParserTest.php
@@ -144,19 +144,18 @@ final class XRef15ParserTest extends TestCase
     }
 
     // ----------------------------------------------------------------
-    // Corpus hardening regression tests (problem #4: invalid xref stream)
+    // Corpus hardening regression tests
     // ----------------------------------------------------------------
 
     /**
-     * Problem #4 (6 corpus cases): /Prev in a 1.5 xref stream points to a classic
-     * xref table, but the bytes at that offset look like `N G obj` (object header).
-     * parsePreviousTable() currently treats any `\d+ \d+ obj` prefix as an xref
-     * stream and calls XRef15Parser::parse(), which throws when the object is not
-     * a valid xref stream.  The exception propagates instead of falling back.
+     * /Prev in a 1.5 xref stream points to a classic xref table, but the bytes
+     * at that offset look like `N G obj` (object header).
+     * parsePreviousTable() treats any `\d+ \d+ obj` prefix as an xref stream
+     * and calls XRef15Parser::parse(), which throws when the object is not a
+     * valid xref stream.  The exception propagates instead of falling back.
      *
-     * Reproduce: /Prev 50, buffer at 50 starts with `1 0 obj` (triggers the xref
-     * stream branch) but objectFromString() throws at that offset.
-     * Expected: parse() returns successfully using the XRef14 fallback path instead.
+     * Reproduce: /Prev offset starts with `1 0 obj` (triggers xref stream branch)
+     * but objectFromString() throws; XRef14 fallback must be attempted instead.
      */
     public function test_parse_falls_back_to_xref14_when_prev_is_classic_table_despite_obj_header_prefix(): void
     {

--- a/tests/Unit/XRef15ParserTest.php
+++ b/tests/Unit/XRef15ParserTest.php
@@ -143,6 +143,77 @@ final class XRef15ParserTest extends TestCase
         self::assertSame(0, $value);
     }
 
+    // ----------------------------------------------------------------
+    // Corpus hardening regression tests (problem #4: invalid xref stream)
+    // ----------------------------------------------------------------
+
+    /**
+     * Problem #4 (6 corpus cases): /Prev in a 1.5 xref stream points to a classic
+     * xref table, but the bytes at that offset look like `N G obj` (object header).
+     * parsePreviousTable() currently treats any `\d+ \d+ obj` prefix as an xref
+     * stream and calls XRef15Parser::parse(), which throws when the object is not
+     * a valid xref stream.  The exception propagates instead of falling back.
+     *
+     * Reproduce: /Prev 50, buffer at 50 starts with `1 0 obj` (triggers the xref
+     * stream branch) but objectFromString() throws at that offset.
+     * Expected: parse() returns successfully using the XRef14 fallback path instead.
+     */
+    public function test_parse_falls_back_to_xref14_when_prev_is_classic_table_despite_obj_header_prefix(): void
+    {
+        // Classic xref table sitting right after a `1 0 obj` artefact at offset 0.
+        // parsePreviousTable() will see `1 0 obj` and try XRef15 first; it must
+        // fall back to XRef14 when that attempt fails.
+        $classicXrefBuffer = "1 0 obj\n" // artefact: looks like an obj header
+            ."xref\n0 2\n"
+            ."0000000000 65535 f\n"
+            ."0000000060 00000 n\n"
+            ."trailer << /Size 2 /Root 1 0 R >>\n";
+
+        $prevPosition = 0; // /Prev points here (starts with `1 0 obj`)
+
+        // Current xref stream at position 100
+        $currentObject = $this->xrefObject(
+            chr(1).pack('n', 77).chr(0), // one type-1 entry: oid 2 → offset 77
+            [1, 2, 1],
+            [2, 1],
+            10
+        );
+        $currentObject['Prev'] = $prevPosition;
+
+        // The document stub: objectFromString() throws for offset 0 (not a real xref stream)
+        $document = new class($currentObject, $classicXrefBuffer) extends PdfDocument {
+            public function __construct(
+                private readonly PDFObject $current,
+                string $buffer
+            ) {
+                $this->setBufferFromString($buffer);
+            }
+
+            public function objectFromString(int|string|null $expectedObjId, int $offset = 0, int &$offsetEnd = 0): PDFObject
+            {
+                if ($offset === 0) {
+                    throw new \Exception('Not a valid xref stream object at offset 0');
+                }
+
+                return $this->current;
+            }
+
+            public function findObjectAtOffset(int $objectOffset, ?int $expectedOid = null): PDFObject
+            {
+                return $this->current;
+            }
+        };
+
+        // Build a buffer that triggers the numeric-prefix detection:
+        // offset 100 = where the current xref object is placed in the mock.
+        $result = (new XRef15Parser)->parse($document, 100);
+
+        // Entries from the current stream must be present
+        self::assertSame(77, $result->table[2]);
+        // Entries from the /Prev classic table should be merged in via the XRef14 fallback
+        self::assertArrayHasKey(1, $result->table);
+    }
+
     private function xrefObject(string $stream, array $w, array $index, int $size): PDFObject
     {
         $wValues = array_map(static fn (int $v): PDFValueSimple => new PDFValueSimple($v), $w);


### PR DESCRIPTION
## Summary
- harden PDF version resolution to scan larger header windows and recover from producer metadata
- improve structure recovery when startxref points to 0 by attempting xref-less recovery path
- improve xref stream previous-table handling for classic xref cases that include obj-like prefixes
- extend FlateDecode header-scan bounds for compressed stream recovery
- align regression fixture for classic trailer parsing with required startxref marker
