### PR TITLE
fix(pdf-core): malformed PDF hardening

### DIFF
--- a/src/Infrastructure/PdfCore/ObjectParser.php
+++ b/src/Infrastructure/PdfCore/ObjectParser.php
@@ -185,6 +185,10 @@ class ObjectParser implements Stringable
                 case self::T_STREAM_BEGIN:
                 case self::T_STREAM_END:
                     throw new PdfCoreParsingException('Invalid list definition');
+                case self::T_DICT_END:
+                    // Stray '>>' inside a list (unclosed array) — return partial list;
+                    // the caller's dict loop will consume '>>' to close the parent dict.
+                    return new PDFValueList($list);
                 default:
                     $value = $this->parseValue();
                     if ($value !== null) {

--- a/src/Infrastructure/PdfCore/PDFObject.php
+++ b/src/Infrastructure/PdfCore/PDFObject.php
@@ -271,7 +271,7 @@ endstream
         // Additional hardening: attempt to recover when arbitrary non-whitespace bytes
         // precede a valid compressed payload (seen in malformed corpus fixtures).
         // Keep a bounded search window to avoid pathological CPU cost on huge streams.
-        $maxSkip = min(2048, max(0, strlen($stream) - 2));
+        $maxSkip = min(65536, max(0, strlen($stream) - 2));
         for ($skip = 1; $skip <= $maxSkip; $skip++) {
             $inflated = self::attemptInflateCandidate(substr($stream, $skip));
             if (is_string($inflated)) {
@@ -287,7 +287,7 @@ endstream
         // If the compressed payload starts far from the stream start, blind linear probing
         // is too expensive. Scan a bounded prefix for plausible zlib/gzip headers first.
         $streamLength = strlen($stream);
-        $maxHeaderScan = min(262144, max(0, $streamLength - 2));
+        $maxHeaderScan = min(1048576, max(0, $streamLength - 2));
         $attempts = 0;
 
         for ($offset = 1; $offset <= $maxHeaderScan; $offset++) {
@@ -305,7 +305,7 @@ endstream
             }
 
             // Keep this fallback bounded to avoid excessive decompression attempts.
-            if ($attempts >= 256) {
+            if ($attempts >= 2048) {
                 break;
             }
         }

--- a/src/Infrastructure/PdfCore/PageInfo.php
+++ b/src/Infrastructure/PdfCore/PageInfo.php
@@ -63,7 +63,13 @@ class PageInfo
         }
 
         if (is_int($pages)) {
-            if ($this->pdfDocument->getObject($pages) === null) {
+            $pagesObjectReachable = false;
+            try {
+                $pagesObjectReachable = ($this->pdfDocument->getObject($pages) !== null);
+            } catch (PdfCoreParsingException) {
+                // xref entry exists but the object at that offset is corrupt or misidentified
+            }
+            if (! $pagesObjectReachable) {
                 $fallbackPages = $this->findFallbackPagesRootOid($root->getOid());
                 if ($fallbackPages !== null) {
                     $pages = $fallbackPages;
@@ -97,7 +103,11 @@ class PageInfo
      */
     protected function getPageInfo(int $oid, ?array $inheritedSize = null, array $visitedOids = []): array
     {
-        $object = $this->pdfDocument->getObject($oid);
+        try {
+            $object = $this->pdfDocument->getObject($oid);
+        } catch (PdfCoreParsingException $e) {
+            throw new PdfCoreStructureException('Could not resolve page tree object '.$oid.'.', 0, $e);
+        }
         if ($object === null) {
             throw new PdfCoreStructureException('Could not resolve page tree object '.$oid.'.');
         }
@@ -153,7 +163,16 @@ class PageInfo
     private function findFallbackCatalogObject(): ?PDFObject
     {
         foreach ($this->discoverObjects() as $candidate) {
-            if ($candidate['Type']?->val() === 'Catalog') {
+            $type = $candidate['Type']?->val();
+            if ($type === 'Catalog') {
+                return $candidate;
+            }
+
+            $pagesRef = $candidate['Pages']?->asObjectReferenceOrNull();
+            $hasPagesReference = is_int($pagesRef)
+                || (is_array($pagesRef) && $pagesRef !== []);
+
+            if (($type === null || $type === '') && $hasPagesReference) {
                 return $candidate;
             }
         }
@@ -189,7 +208,13 @@ class PageInfo
         $descriptors = [];
 
         foreach ($this->discoverObjects() as $candidate) {
-            if ($candidate['Type']?->val() !== 'Page') {
+            $type = $candidate['Type']?->val();
+            $isExplicitPage = $type === 'Page';
+            $isPageLikeWithoutType = ($type === null || $type === '')
+                && isset($candidate['MediaBox'])
+                && (isset($candidate['Parent']) || isset($candidate['Contents']));
+
+            if (! $isExplicitPage && ! $isPageLikeWithoutType) {
                 continue;
             }
 
@@ -266,7 +291,7 @@ class PageInfo
             return $objects;
         }
 
-        if (preg_match_all('/(?:^|[\r\n])(\d+)\s+(\d+)\s+obj\b/m', $buffer, $matches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE) === 0) {
+        if (preg_match_all('/(?:^|[\r\n\x00])(\d+)\s+(\d+)\s+obj\b/m', $buffer, $matches, PREG_SET_ORDER | PREG_OFFSET_CAPTURE) === 0) {
             return $objects;
         }
 

--- a/src/Infrastructure/PdfCore/Service/PdfObjectReader.php
+++ b/src/Infrastructure/PdfCore/Service/PdfObjectReader.php
@@ -15,6 +15,13 @@ final class PdfObjectReader
     {
         $bufferLength = strlen($buffer);
         if ($offset < 0 || $offset >= $bufferLength) {
+            if (($expectedObjId !== null) && ((int) $expectedObjId > 0)) {
+                $fallbackOffset = $this->findExpectedObjectHeaderOffset($buffer, (int) $expectedObjId, -1);
+                if ($fallbackOffset !== null) {
+                    return $this->objectFromBuffer($buffer, $expectedObjId, $fallbackOffset, $offsetEnd);
+                }
+            }
+
             throw new PdfCoreParsingException('Invalid object definition: '.$expectedObjId);
         }
 
@@ -58,6 +65,10 @@ final class PdfObjectReader
             if ($tok === ObjectParser::T_STREAM_BEGIN || $tok === ObjectParser::T_OBJECT_END) {
                 break;
             }
+            if ($tok === ObjectParser::T_OBJECT_BEGIN) {
+                // Next object's header started without an `endobj` — treat as implicit endobj.
+                break;
+            }
             if ($tok === ObjectParser::T_COMMENT
                 || $tok === ObjectParser::T_LIST_START
                 || $tok === ObjectParser::T_LIST_END
@@ -82,27 +93,51 @@ final class PdfObjectReader
             return null;
         }
 
-        $scanStart = max(0, $offset + 1);
-        $scanWindowLength = min(262144, max(0, strlen($buffer) - $scanStart));
+        $bufferLength = strlen($buffer);
+        $windowStart = max(0, $offset - 1048576);
+        $windowEnd = min($bufferLength, max($offset + 1048576, 0));
+        if ($windowEnd <= $windowStart) {
+            $windowStart = 0;
+            $windowEnd = $bufferLength;
+        }
+
+        $scanStart = $windowStart;
+        $scanWindowLength = $windowEnd - $windowStart;
         if ($scanWindowLength === 0) {
             return null;
         }
 
         $window = substr($buffer, $scanStart, $scanWindowLength);
         $pattern = '/(?:^|[\r\n\x00\x09\x0C\x20])'.preg_quote((string) $expectedObjId, '/').'\s+\d+\s+obj\b/';
-        if (preg_match($pattern, $window, $match, PREG_OFFSET_CAPTURE) !== 1) {
+        if (preg_match_all($pattern, $window, $matches, PREG_OFFSET_CAPTURE) !== 1) {
             return null;
         }
 
-        $relativeOffset = (int) ($match[0][1] ?? -1);
-        if ($relativeOffset < 0) {
+        $bestOffset = null;
+        $bestDistance = PHP_INT_MAX;
+
+        foreach (($matches[0] ?? []) as $match) {
+            $relativeOffset = (int) ($match[1] ?? -1);
+            if ($relativeOffset < 0) {
+                continue;
+            }
+
+            $header = (string) ($match[0] ?? '');
+            $leadingWhitespace = strlen($header) - strlen(ltrim($header, "\r\n\x00\x09\x0C\x20"));
+            $candidate = $scanStart + $relativeOffset + $leadingWhitespace;
+            $distance = abs($candidate - $offset);
+
+            if ($distance < $bestDistance) {
+                $bestDistance = $distance;
+                $bestOffset = $candidate;
+            }
+        }
+
+        if (! is_int($bestOffset)) {
             return null;
         }
 
-        $header = (string) ($match[0][0] ?? '');
-        $leadingWhitespace = strlen($header) - strlen(ltrim($header, "\r\n\x00\x09\x0C\x20"));
-
-        return $scanStart + $relativeOffset + $leadingWhitespace;
+        return $bestOffset;
     }
 
     public function parseObjectDefinitionString(string $objectDefinition, int $expectedOid): PDFObject

--- a/src/Infrastructure/PdfCore/Service/PdfObjectReader.php
+++ b/src/Infrastructure/PdfCore/Service/PdfObjectReader.php
@@ -118,9 +118,6 @@ final class PdfObjectReader
 
         foreach (($matches[0] ?? []) as $match) {
             $relativeOffset = (int) ($match[1] ?? -1);
-            if ($relativeOffset < 0) {
-                continue;
-            }
 
             $header = (string) ($match[0] ?? '');
             $leadingWhitespace = strlen($header) - strlen(ltrim($header, "\r\n\x00\x09\x0C\x20"));
@@ -131,10 +128,6 @@ final class PdfObjectReader
                 $bestDistance = $distance;
                 $bestOffset = $candidate;
             }
-        }
-
-        if (! is_int($bestOffset)) {
-            return null;
         }
 
         return $bestOffset;

--- a/src/Infrastructure/PdfCore/Service/TrailerObjectResolver.php
+++ b/src/Infrastructure/PdfCore/Service/TrailerObjectResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SignerPHP\Infrastructure\PdfCore\Service;
 
+use SignerPHP\Infrastructure\PdfCore\Exception\PdfCoreParsingException;
 use SignerPHP\Infrastructure\PdfCore\Exception\PdfCoreStructureException;
 use SignerPHP\Infrastructure\PdfCore\PdfDocument;
 use SignerPHP\Infrastructure\PdfCore\PDFObject;
@@ -12,13 +13,54 @@ final class TrailerObjectResolver
 {
     public function resolveRootObject(PdfDocument $document): PDFObject
     {
-        $rootObjectId = $this->resolveRequiredReference($document, 'Root', 'root object');
-        $rootObject = $document->getObject($rootObjectId);
+        $rootObject = null;
+
+        try {
+            $rootObjectId = $this->resolveRequiredReference($document, 'Root', 'root object');
+            $rootObject = $document->getObject($rootObjectId);
+        } catch (PdfCoreStructureException) {
+            $rootObject = null;
+        }
+
+        if ($rootObject === null) {
+            $rootObject = $this->findFallbackCatalogObject($document);
+        }
+
         if ($rootObject === null) {
             throw new PdfCoreStructureException('Invalid root object');
         }
 
         return $rootObject;
+    }
+
+    private function findFallbackCatalogObject(PdfDocument $document): ?PDFObject
+    {
+        $objects = $document->getPdfObjects();
+
+        foreach ($objects as $candidate) {
+            if ($candidate instanceof PDFObject && $candidate['Type']?->val() === 'Catalog') {
+                return $candidate;
+            }
+        }
+
+        foreach ($document->getXrefTable() as $oid => $entry) {
+            $oid = (int) $oid;
+            if ($oid === 0 || isset($objects[$oid])) {
+                continue;
+            }
+
+            try {
+                $candidate = $document->getObject($oid);
+            } catch (PdfCoreParsingException|PdfCoreStructureException) {
+                continue;
+            }
+
+            if ($candidate instanceof PDFObject && $candidate['Type']?->val() === 'Catalog') {
+                return $candidate;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/tests/Infrastructure/PdfCore/Service/PdfObjectReaderTest.php
+++ b/tests/Infrastructure/PdfCore/Service/PdfObjectReaderTest.php
@@ -35,15 +35,15 @@ final class PdfObjectReaderTest extends TestCase
         self::assertGreaterThan(0, $offsetEnd);
     }
 
-    public function test_object_from_buffer_throws_parsing_exception_when_offset_is_beyond_buffer(): void
+    public function test_object_from_buffer_throws_parsing_exception_when_offset_is_beyond_buffer_and_object_is_not_recoverable(): void
     {
         $reader = new PdfObjectReader;
         $buffer = "1 0 obj\n<< /Type /Catalog >>\nendobj\n";
 
         $this->expectException(\SignerPHP\Infrastructure\PdfCore\Exception\PdfCoreParsingException::class);
-        $this->expectExceptionMessage('Invalid object definition: 1');
+        $this->expectExceptionMessage('Invalid object definition: 9');
 
         $offsetEnd = 0;
-        $reader->objectFromBuffer($buffer, 1, strlen($buffer) + 10, $offsetEnd);
+        $reader->objectFromBuffer($buffer, 9, strlen($buffer) + 10, $offsetEnd);
     }
 }

--- a/tests/Unit/ObjectParserTest.php
+++ b/tests/Unit/ObjectParserTest.php
@@ -107,6 +107,19 @@ final class ObjectParserTest extends TestCase
         $parser->parseString('[obj]');
     }
 
+    public function test_parser_recovers_from_unclosed_array_when_dict_end_is_encountered(): void
+    {
+        // Simulates poppler-937-0-fuzzed.pdf: a list that never closes with `]`
+        // and the outer dict's `>>` is encountered inside it.
+        $parser = new ObjectParser;
+
+        $parsed = $parser->parseString('<< /Type /Pages /MediaBox [0 0 612 792 /Count 1 >>');
+
+        self::assertInstanceOf(PDFValueObject::class, $parsed);
+        self::assertSame('Pages', $parsed['Type']->val());
+        self::assertNotNull($parsed['MediaBox']);
+    }
+
     public function test_parser_throws_when_only_comment_is_present(): void
     {
         $parser = new ObjectParser;

--- a/tests/Unit/ObjectStreamResolverTest.php
+++ b/tests/Unit/ObjectStreamResolverTest.php
@@ -247,7 +247,7 @@ final class ObjectStreamResolverTest extends TestCase
         $objectStream = new PDFObject(99, [
             'Type' => '/ObjStm',
             'First' => strlen($index),
-            'N' => 1,
+            'N' => 2,
         ]);
         $objectStream->setStream($index.'<< /Type /Catalog >>');
 
@@ -297,6 +297,33 @@ final class ObjectStreamResolverTest extends TestCase
     {
         $index = '9 0 20 5 ';
         $payload = 'null << /Type /Catalog >>';
+        $objectStream = new PDFObject(99, [
+            'Type' => '/ObjStm',
+            'First' => strlen($index),
+            'N' => 1,
+        ]);
+        $objectStream->setStream($index.$payload);
+
+        $document = new class($objectStream) extends PdfDocument
+        {
+            public function __construct(private readonly PDFObject $objectStream) {}
+
+            public function findObject(int $oid): ?PDFObject
+            {
+                return $oid === 99 ? $this->objectStream : null;
+            }
+        };
+
+        $resolved = (new ObjectStreamResolver)->resolveFromObjectStream($document, 99, 0, 20);
+
+        self::assertSame(20, $resolved->getOid());
+        self::assertSame('Catalog', $resolved['Type']->val());
+    }
+
+    public function test_resolve_from_object_stream_recovers_when_index_has_trailing_orphan_number(): void
+    {
+        $index = '20 0 999 ';
+        $payload = '<< /Type /Catalog >>';
         $objectStream = new PDFObject(99, [
             'Type' => '/ObjStm',
             'First' => strlen($index),

--- a/tests/Unit/PDFObjectTest.php
+++ b/tests/Unit/PDFObjectTest.php
@@ -223,6 +223,27 @@ final class PDFObjectTest extends TestCase
         }
     }
 
+    public function test_get_stream_breaks_header_scan_after_too_many_failed_header_candidates(): void
+    {
+        $object = new PDFObject(1, ['Filter' => '/FlateDecode']);
+
+        // Feed a long sequence of plausible zlib-looking bytes that still do not form a valid
+        // compressed payload, so the bounded header scan exhausts its 2048 attempts.
+        $object->setStream(str_repeat("\x78\x9C", 2050));
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Failed to inflate FlateDecode stream.');
+
+        set_error_handler(static function (): bool {
+            return true;
+        });
+        try {
+            $object->getStream(false);
+        } finally {
+            restore_error_handler();
+        }
+    }
+
     /**
      * @return array<string, array{callable(string):string|false}>
      */

--- a/tests/Unit/PDFObjectTest.php
+++ b/tests/Unit/PDFObjectTest.php
@@ -376,4 +376,53 @@ final class PDFObjectTest extends TestCase
         // Must find and decompress the gzip payload beyond the 65536-byte window
         self::assertSame($expected, $object->getStream(false));
     }
+
+    public function test_get_stream_decodes_flate_with_gzip_header_beyond_262144_byte_scan_window(): void
+    {
+        $expected = 'corpus-gzip-payload-after-262k-window';
+        $validGzip = gzencode($expected);
+        self::assertIsString($validGzip);
+
+        // 300 000 bytes of non-header junk before a valid gzip payload.
+        // Current bounded header scan at 262 144 cannot reach this offset.
+        $garbage = str_repeat("\x00\x01", 150000); // 300 000 bytes
+
+        $object = new PDFObject(1, ['Filter' => '/FlateDecode']);
+        $object->setStream($garbage.$validGzip);
+
+        self::assertSame($expected, $object->getStream(false));
+    }
+
+    public function test_get_stream_decodes_flate_after_more_than_256_fake_headers(): void
+    {
+        $expected = 'corpus-payload-after-256-fake-headers';
+        $validZlib = gzcompress($expected);
+        self::assertIsString($validZlib);
+
+        // 300 fake zlib headers before the real payload.
+        // A hard cap of 256 decompression attempts misses the valid payload.
+        $fakeBlock = "\x78\x9C".str_repeat("\xFF", 38); // 40 bytes each
+        $garbage = str_repeat($fakeBlock, 300);
+
+        $object = new PDFObject(1, ['Filter' => '/FlateDecode']);
+        $object->setStream($garbage.$validZlib);
+
+        self::assertSame($expected, $object->getStream(false));
+    }
+
+    public function test_get_stream_decodes_raw_deflate_with_non_whitespace_prefix_beyond_2048_bytes(): void
+    {
+        $expected = 'corpus-raw-deflate-after-large-prefix';
+        $rawDeflate = gzdeflate($expected);
+        self::assertIsString($rawDeflate);
+
+        // Prefix contains non-whitespace bytes only, so ltrim() fallback cannot help.
+        // Current bounded prefix probing at 2048 bytes cannot reach the payload.
+        $prefix = str_repeat("\xFF", 3000);
+
+        $object = new PDFObject(1, ['Filter' => '/FlateDecode']);
+        $object->setStream($prefix.$rawDeflate);
+
+        self::assertSame($expected, $object->getStream(false));
+    }
 }

--- a/tests/Unit/PageInfoTest.php
+++ b/tests/Unit/PageInfoTest.php
@@ -149,6 +149,42 @@ final class PageInfoTest extends TestCase
         self::assertNotNull($pageInfo->getPage(0));
     }
 
+    public function test_acquire_pages_info_inferrs_catalog_when_type_is_missing_but_pages_reference_exists(): void
+    {
+        $document = new PdfDocument;
+        $document->setTrailerObject(new PDFValueObject([
+            'Root' => new PDFValueReference(99),
+        ]));
+        $document->addObject(new PDFObject(1, [
+            'Pages' => new PDFValueReference(2),
+        ]));
+        $document->addObject(new PDFObject(2, [
+            'Type' => '/Pages',
+            'Kids' => [3],
+            'Count' => 1,
+            'MediaBox' => [0, 0, 10, 10],
+        ]));
+        $document->addObject(new PDFObject(3, [
+            'Type' => '/Page',
+            'Parent' => new PDFValueReference(2),
+        ]));
+
+        $pageInfo = PageInfo::new()
+            ->withPdfDocument($document)
+            ->acquirePagesInfo();
+
+        self::assertNotNull($pageInfo->getPage(0));
+        $size = $pageInfo->getPageSize(0);
+        self::assertIsArray($size);
+        self::assertSame(
+            [0, 0, 10, 10],
+            array_map(
+                static fn (mixed $value): mixed => is_object($value) && method_exists($value, 'val') ? $value->val() : $value,
+                $size
+            )
+        );
+    }
+
     public function test_acquire_pages_info_falls_back_to_catalog_discovered_from_raw_buffer_when_xref_cannot_resolve_root(): void
     {
         $document = new PdfDocument;
@@ -160,6 +196,26 @@ final class PageInfoTest extends TestCase
             "1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n"
             ."2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n"
             ."3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 10 10] >>\nendobj\n"
+        );
+
+        $pageInfo = PageInfo::new()
+            ->withPdfDocument($document)
+            ->acquirePagesInfo();
+
+        self::assertNotNull($pageInfo->getPage(0));
+    }
+
+    public function test_acquire_pages_info_falls_back_to_catalog_discovered_from_raw_buffer_with_null_delimiters(): void
+    {
+        $document = new PdfDocument;
+        $document->setTrailerObject(new PDFValueObject([
+            'Root' => new PDFValueReference(99),
+        ]));
+        $document->setXrefTable([]);
+        $document->setBufferFromString(
+            "\x00"."1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n"
+            ."\x00"."2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n"
+            ."\x00"."3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 10 10] >>\nendobj\n"
         );
 
         $pageInfo = PageInfo::new()
@@ -301,6 +357,52 @@ final class PageInfoTest extends TestCase
         PageInfo::new()
             ->withPdfDocument($document)
             ->acquirePagesInfo();
+    }
+
+    public function test_acquire_pages_info_inferrs_pages_node_when_type_is_missing_but_kids_are_present(): void
+    {
+        $document = new PdfDocument;
+        $document->setTrailerObject(new PDFValueObject([
+            'Root' => new PDFValueReference(1),
+        ]));
+        $document->addObject(new PDFObject(1, [
+            'Type' => '/Catalog',
+            'Pages' => new PDFValueReference(2),
+        ]));
+        $document->addObject(new PDFObject(2, [
+            'Kids' => [3],
+            'Count' => 1,
+        ]));
+        $document->addObject(new PDFObject(3, [
+            'Type' => '/Page',
+            'Parent' => new PDFValueReference(2),
+            'MediaBox' => [0, 0, 10, 10],
+        ]));
+
+        $pageInfo = PageInfo::new()
+            ->withPdfDocument($document)
+            ->acquirePagesInfo();
+
+        self::assertNotNull($pageInfo->getPage(0));
+    }
+
+    public function test_acquire_pages_info_falls_back_to_loose_page_like_object_when_type_is_missing(): void
+    {
+        $document = new PdfDocument;
+        $document->setTrailerObject(new PDFValueObject([
+            'Root' => new PDFValueReference(999),
+        ]));
+        $document->addObject(new PDFObject(7, [
+            'Parent' => new PDFValueReference(2),
+            'MediaBox' => [0, 0, 20, 20],
+            'Contents' => new PDFValueReference(8),
+        ]));
+
+        $pageInfo = PageInfo::new()
+            ->withPdfDocument($document)
+            ->acquirePagesInfo();
+
+        self::assertNotNull($pageInfo->getPage(0));
     }
 
     public function test_acquire_pages_info_fails_when_pages_node_has_invalid_kids_list(): void
@@ -513,6 +615,41 @@ final class PageInfoTest extends TestCase
         $this->setPagesInfo($pageInfo, [new PageDescriptor(1, [1, 2, 3, 4])]);
 
         self::assertNull($pageInfo->getPageSize(new PDFObject(99, ['Type' => '/Page'])));
+    }
+
+    public function test_acquire_pages_info_falls_back_to_loose_pages_when_pages_oid_throws_parsing_exception(): void
+    {
+        // Simulates poppler-395-0-fuzzed.pdf: catalog's /Pages references an OID whose
+        // xref offset is corrupt (wrong object found) — getObject() throws PdfCoreParsingException.
+        $document = new class extends PdfDocument
+        {
+            public function getObject(int $oid, bool $originalVersion = false): ?PDFObject
+            {
+                if ($oid === 2) {
+                    throw new PdfCoreParsingException('PDF structure is corrupt: found obj 3 while searching for obj 2 (at 174).');
+                }
+
+                return parent::getObject($oid, $originalVersion);
+            }
+        };
+
+        $document->setTrailerObject(new PDFValueObject([
+            'Root' => new PDFValueReference(1),
+        ]));
+        $document->addObject(new PDFObject(1, [
+            'Type' => '/Catalog',
+            'Pages' => new PDFValueReference(2),
+        ]));
+        $document->addObject(new PDFObject(5, [
+            'Type' => '/Page',
+            'MediaBox' => [0, 0, 612, 792],
+        ]));
+
+        $pageInfo = PageInfo::new()
+            ->withPdfDocument($document)
+            ->acquirePagesInfo();
+
+        self::assertNotNull($pageInfo->getPage(0));
     }
 
     /** @param array<int, PageDescriptor> $descriptors */

--- a/tests/Unit/PageInfoTest.php
+++ b/tests/Unit/PageInfoTest.php
@@ -225,6 +225,52 @@ final class PageInfoTest extends TestCase
         self::assertNotNull($pageInfo->getPage(0));
     }
 
+    public function test_acquire_pages_info_falls_back_to_alternate_pages_root_when_catalog_pages_reference_throws_parsing_exception(): void
+    {
+        $document = new class extends PdfDocument
+        {
+            public function __construct()
+            {
+                $this->setTrailerObject(new PDFValueObject([
+                    'Root' => new PDFValueReference(1),
+                ]));
+
+                $this->addObject(new PDFObject(1, [
+                    'Type' => '/Catalog',
+                    'Pages' => new PDFValueReference(2),
+                ]));
+                $this->addObject(new PDFObject(3, [
+                    'Type' => '/Pages',
+                    'Parent' => new PDFValueReference(1),
+                    'Kids' => [4],
+                    'Count' => 1,
+                ]));
+                $this->addObject(new PDFObject(4, [
+                    'Type' => '/Page',
+                    'Parent' => new PDFValueReference(3),
+                    'MediaBox' => [0, 0, 10, 10],
+                ]));
+            }
+
+            public function getObject(int $oid, bool $originalVersion = false): ?PDFObject
+            {
+                return match ($oid) {
+                    1 => parent::getObject($oid, $originalVersion),
+                    2 => throw new PdfCoreParsingException('synthetic xref parsing failure'),
+                    3 => parent::getObject($oid, $originalVersion),
+                    4 => parent::getObject($oid, $originalVersion),
+                    default => null,
+                };
+            }
+        };
+
+        $pageInfo = PageInfo::new()
+            ->withPdfDocument($document)
+            ->acquirePagesInfo();
+
+        self::assertNotNull($pageInfo->getPage(0));
+    }
+
     public function test_acquire_pages_info_falls_back_to_loose_pages_when_root_and_catalog_are_unresolvable(): void
     {
         $document = new PdfDocument;

--- a/tests/Unit/PdfObjectReaderTest.php
+++ b/tests/Unit/PdfObjectReaderTest.php
@@ -55,6 +55,18 @@ final class PdfObjectReaderTest extends TestCase
         $reader->objectFromBuffer($buffer, 9, 0, $offsetEnd);
     }
 
+    public function test_object_from_buffer_with_non_positive_expected_oid_does_not_trigger_header_recovery(): void
+    {
+        $reader = new PdfObjectReader;
+        $buffer = "3 0 obj\n<< /Type /Catalog >>\nendobj\n";
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('PDF structure is corrupt: found obj 3 while searching for obj 0');
+
+        $offsetEnd = 0;
+        $reader->objectFromBuffer($buffer, 0, 0, $offsetEnd);
+    }
+
     public function test_object_from_buffer_recovers_when_expected_object_header_appears_later_in_buffer(): void
     {
         $reader = new PdfObjectReader;
@@ -67,6 +79,81 @@ final class PdfObjectReaderTest extends TestCase
         self::assertSame(9, $object->getOid());
         self::assertSame('Page', $object['Type']->val());
         self::assertGreaterThan(0, $offsetEnd);
+    }
+
+    public function test_object_from_buffer_recovers_when_expected_object_header_is_before_stale_offset(): void
+    {
+        $reader = new PdfObjectReader;
+        $buffer = "1 0 obj\n<< /Type /Catalog >>\nendobj\n"
+            ."2 0 obj\n<< /Type /Page >>\nendobj\n";
+
+        $staleOffset = strpos($buffer, '2 0 obj');
+        self::assertIsInt($staleOffset);
+
+        $offsetEnd = 0;
+        $object = $reader->objectFromBuffer($buffer, 1, $staleOffset, $offsetEnd);
+
+        self::assertSame(1, $object->getOid());
+        self::assertSame('Catalog', $object['Type']->val());
+        self::assertGreaterThan(0, $offsetEnd);
+    }
+
+    public function test_object_from_buffer_recovers_when_expected_object_is_before_offset_with_large_gap(): void
+    {
+        $reader = new PdfObjectReader;
+        $buffer = "1 0 obj\n<< /Type /Catalog >>\nendobj\n"
+            .str_repeat('A', 400000)
+            ."2 0 obj\n<< /Type /Page >>\nendobj\n";
+
+        $staleOffset = strpos($buffer, '2 0 obj');
+        self::assertIsInt($staleOffset);
+
+        $offsetEnd = 0;
+        $object = $reader->objectFromBuffer($buffer, 1, $staleOffset, $offsetEnd);
+
+        self::assertSame(1, $object->getOid());
+        self::assertSame('Catalog', $object['Type']->val());
+        self::assertGreaterThan(0, $offsetEnd);
+    }
+
+    public function test_object_from_buffer_recovers_when_expected_object_is_beyond_262144_scan_window(): void
+    {
+        $reader = new PdfObjectReader;
+        $buffer = "3 0 obj\n<< /Type /Catalog >>\nendobj\n"
+            .str_repeat('A', 300000)
+            ."\n9 0 obj\n<< /Type /Page >>\nendobj\n";
+
+        $offsetEnd = 0;
+        $object = $reader->objectFromBuffer($buffer, 9, 0, $offsetEnd);
+
+        self::assertSame(9, $object->getOid());
+        self::assertSame('Page', $object['Type']->val());
+        self::assertGreaterThan(0, $offsetEnd);
+    }
+
+    public function test_object_from_buffer_recovers_from_invalid_offset_by_searching_expected_header(): void
+    {
+        $reader = new PdfObjectReader;
+        $buffer = str_repeat('X', 64)
+            ."\n2 0 obj\n<< /Type /Page >>\nendobj\n";
+
+        $offsetEnd = 0;
+        $object = $reader->objectFromBuffer($buffer, 2, 999999, $offsetEnd);
+
+        self::assertSame(2, $object->getOid());
+        self::assertSame('Page', $object['Type']->val());
+        self::assertGreaterThan(0, $offsetEnd);
+    }
+
+    public function test_object_from_buffer_with_empty_buffer_throws_invalid_object_definition(): void
+    {
+        $reader = new PdfObjectReader;
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Invalid object definition: 1');
+
+        $offsetEnd = 0;
+        $reader->objectFromBuffer('', 1, 0, $offsetEnd);
     }
 
     public function test_object_from_buffer_accepts_null_expected_oid(): void
@@ -112,5 +199,19 @@ final class PdfObjectReaderTest extends TestCase
         self::assertSame(4, $object->getOid());
         self::assertSame(3, $object->getGeneration());
         self::assertSame('Catalog', $object['Type']->val());
+    }
+
+    public function test_object_from_buffer_succeeds_when_endobj_is_missing_and_next_object_follows(): void
+    {
+        // PDFs like issue10438_reduced.pdf have objects with valid dicts but no `endobj`.
+        // The next `N 0 obj` header should be treated as an implicit endobj.
+        $reader = new PdfObjectReader;
+        $buffer = "1 0 obj\n<<\n/Title (Test)\n>>\n2 0 obj\n<< /Type /Catalog >>\nendobj\n";
+        $offsetEnd = 0;
+
+        $object = $reader->objectFromBuffer($buffer, 1, 0, $offsetEnd);
+
+        self::assertSame(1, $object->getOid());
+        self::assertSame('Test', $object['Title']->val());
     }
 }

--- a/tests/Unit/TrailerObjectResolverTest.php
+++ b/tests/Unit/TrailerObjectResolverTest.php
@@ -33,7 +33,7 @@ final class TrailerObjectResolverTest extends TestCase
         $document->setTrailerObject(new PDFValueObject);
 
         $this->expectException(PdfCoreStructureException::class);
-        $this->expectExceptionMessage('Could not find the root object from the trailer');
+        $this->expectExceptionMessage('Invalid root object');
 
         (new TrailerObjectResolver)->resolveRootObject($document);
     }
@@ -91,5 +91,31 @@ final class TrailerObjectResolverTest extends TestCase
         $this->expectExceptionMessage('Invalid root object');
 
         (new TrailerObjectResolver)->resolveRootObject($document);
+    }
+
+    public function test_resolve_root_object_falls_back_to_catalog_when_root_reference_is_missing(): void
+    {
+        $document = new PdfDocument;
+        $catalog = new PDFObject(7, ['Type' => '/Catalog']);
+
+        $document->setTrailerObject(new PDFValueObject);
+        $document->addObject($catalog);
+
+        $resolved = (new TrailerObjectResolver)->resolveRootObject($document);
+
+        self::assertSame($catalog, $resolved);
+    }
+
+    public function test_resolve_root_object_falls_back_to_catalog_when_root_reference_is_stale(): void
+    {
+        $document = new PdfDocument;
+        $catalog = new PDFObject(9, ['Type' => '/Catalog']);
+
+        $document->setTrailerObject(new PDFValueObject(['Root' => new PDFValueReference(2)]));
+        $document->addObject($catalog);
+
+        $resolved = (new TrailerObjectResolver)->resolveRootObject($document);
+
+        self::assertSame($catalog, $resolved);
     }
 }

--- a/tests/Unit/TrailerObjectResolverTest.php
+++ b/tests/Unit/TrailerObjectResolverTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SignerPHP\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
+use SignerPHP\Infrastructure\PdfCore\Exception\PdfCoreParsingException;
 use SignerPHP\Infrastructure\PdfCore\Exception\PdfCoreStructureException;
 use SignerPHP\Infrastructure\PdfCore\PdfDocument;
 use SignerPHP\Infrastructure\PdfCore\PDFObject;
@@ -117,5 +118,39 @@ final class TrailerObjectResolverTest extends TestCase
         $resolved = (new TrailerObjectResolver)->resolveRootObject($document);
 
         self::assertSame($catalog, $resolved);
+    }
+
+    public function test_resolve_root_object_skips_parsing_failures_while_scanning_xref_for_catalog(): void
+    {
+        $document = new class extends PdfDocument
+        {
+            public function __construct()
+            {
+                $this->setTrailerObject(new PDFValueObject(['Root' => new PDFValueReference(2)]));
+            }
+
+            public function getPdfObjects(): array
+            {
+                return [];
+            }
+
+            public function getXrefTable(): array
+            {
+                return [0 => 0, 4 => 40, 5 => 50];
+            }
+
+            public function getObject(int $oid, bool $originalVersion = false): ?PDFObject
+            {
+                return match ($oid) {
+                    4 => throw new PdfCoreParsingException('synthetic xref parsing failure'),
+                    5 => new PDFObject(5, ['Type' => '/Catalog']),
+                    default => null,
+                };
+            }
+        };
+
+        $resolved = (new TrailerObjectResolver)->resolveRootObject($document);
+
+        self::assertSame(5, $resolved->getOid());
     }
 }


### PR DESCRIPTION
## Summary
- treat next-object header as implicit endobj for PDFs missing the `endobj` keyword between objects
- recover partial list when `>>` is reached inside an unclosed array value
- handle `PdfCoreParsingException` when the catalog `/Pages` OID maps to a corrupt xref offset, falling back to loose page discovery
- fall back to catalog scan when the trailer `/Root` OID is unresolvable due to a corrupt cross-reference
- extend FlateDecode junk-prefix scan limits to handle larger malformed compressed streams